### PR TITLE
Refactor: shrink Main.java by extracting single-purpose classes

### DIFF
--- a/core/src/main/java/com/github/tommyettinger/BinaryExec.java
+++ b/core/src/main/java/com/github/tommyettinger/BinaryExec.java
@@ -1,0 +1,97 @@
+package com.github.tommyettinger;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.utils.SharedLibraryLoader;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Helpers for launching the bundled native binaries (msdf-atlas-gen
+ * and oxipng).
+ * <p>
+ * Each call verifies that the binary exists and is executable, then
+ * runs it with {@link ProcessBuilder#inheritIO() inheritIO} and the
+ * given working directory. All common failure modes (missing binary,
+ * non-executable binary, {@link IOException}, {@link InterruptedException})
+ * print a user-facing message via {@link CliMessages} and terminate
+ * the JVM with exit code 1 — callers never need to handle those cases.
+ * <p>
+ * Two flavors are exposed:
+ * <ul>
+ *   <li>{@link #run(String, String, List, File)} returns the process
+ *       exit code so the caller can react to it (used by the
+ *       msdf-atlas-gen retry loop, which shrinks the font size on
+ *       non-zero exit).</li>
+ *   <li>{@link #runOrExit(String, String, List, File)} additionally
+ *       terminates the JVM on any non-zero exit code (used by the
+ *       oxipng sites, where a failed run is unrecoverable).</li>
+ * </ul>
+ */
+final class BinaryExec {
+
+    private BinaryExec() {} // utility class
+
+    /**
+     * Verifies the binary, runs it, and returns its exit code. Exits
+     * the JVM with code 1 if the binary is missing, not executable,
+     * throws an {@link IOException}, or the current thread is
+     * interrupted while waiting.
+     *
+     * @param binaryPath relative path to the binary (e.g.
+     *                   {@code "distbin/mac-arm64/msdf-atlas-gen"})
+     * @param binaryName human-readable name for error messages
+     * @param command    full command line; {@code command.get(0)} is
+     *                   typically {@code binaryPath}
+     * @param workingDir working directory for the child process
+     * @return the process exit code
+     */
+    public static int run(String binaryPath, String binaryName, List<String> command, File workingDir) {
+        verify(binaryPath, binaryName);
+        ProcessBuilder builder = new ProcessBuilder(command);
+        builder.directory(workingDir);
+        builder.inheritIO();
+        try {
+            return builder.start().waitFor();
+        } catch (IOException e) {
+            CliMessages.printBinaryRunFailed(binaryName, e.getMessage(), SharedLibraryLoader.os);
+            System.exit(1);
+        } catch (InterruptedException e) {
+            CliMessages.printBinaryInterrupted(binaryName, e.getMessage());
+            System.exit(1);
+        }
+        return -1; // unreachable; System.exit above
+    }
+
+    /**
+     * Like {@link #run}, but additionally terminates the JVM with the
+     * process exit code if it is non-zero. Use this for steps whose
+     * failure is unrecoverable.
+     */
+    public static void runOrExit(String binaryPath, String binaryName, List<String> command, File workingDir) {
+        int exitCode = run(binaryPath, binaryName, command, workingDir);
+        if (exitCode != 0) {
+            CliMessages.printBinaryExitFailure(binaryName, exitCode);
+            System.exit(exitCode);
+        }
+    }
+
+    /**
+     * Checks that the binary at {@code binaryPath} exists and is
+     * executable. Prints a user-facing diagnostic and exits with code
+     * 1 otherwise.
+     */
+    private static void verify(String binaryPath, String binaryName) {
+        File binaryFile = new File(Gdx.files.getLocalStoragePath(), binaryPath);
+        if (!binaryFile.exists()) {
+            CliMessages.printBinaryNotFound(binaryName, binaryFile.getAbsolutePath());
+            System.exit(1);
+        }
+        if (!binaryFile.canExecute()) {
+            CliMessages.printBinaryNotExecutable(binaryName, binaryPath,
+                    binaryFile.getAbsolutePath(), SharedLibraryLoader.os);
+            System.exit(1);
+        }
+    }
+}

--- a/core/src/main/java/com/github/tommyettinger/CharMapBuilder.java
+++ b/core/src/main/java/com/github/tommyettinger/CharMapBuilder.java
@@ -1,0 +1,216 @@
+package com.github.tommyettinger;
+
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.utils.IntArray;
+import com.badlogic.gdx.utils.IntSet;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static java.awt.Font.TRUETYPE_FONT;
+
+/**
+ * Builds the character map (cmap) passed to msdf-atlas-gen.
+ * <p>
+ * The cmap is a space-separated list of decimal codepoints that the
+ * generated atlas must contain. Building it has three stages:
+ * <ol>
+ *   <li><b>Source selection</b> — which codepoints are candidates? The
+ *       {@link FontwriterConfig#resolveCharsetStrategy() strategy}
+ *       chooses between a predefined preset (e.g. LATIN, CYRILLIC),
+ *       the union of characters found in {@code --lang} files, or
+ *       the full BMP range 32–65535.</li>
+ *   <li><b>Filtering</b> — control characters, C1 controls, and
+ *       bidirectional/formatting codepoints are removed, and each
+ *       candidate is checked against the actual AWT {@link java.awt.Font}
+ *       via {@link java.awt.Font#canDisplay(int) canDisplay} so the
+ *       atlas only requests glyphs the TTF can produce.</li>
+ *   <li><b>Serialization</b> — the surviving codepoints are written
+ *       to the cmap file as space-separated decimals.</li>
+ * </ol>
+ * The builder prints progress to stdout and routes {@code --lang}
+ * failure diagnostics through {@link CliMessages}. On fatal errors
+ * (no lang matches, unreadable font file) it terminates the JVM with
+ * exit code 1.
+ */
+final class CharMapBuilder {
+
+    private CharMapBuilder() {} // utility class
+
+    /**
+     * Bidirectional/formatting and similar "weird" codepoints that
+     * should never end up in the atlas even if the font advertises
+     * glyphs for them. Must be kept sorted for
+     * {@link Arrays#binarySearch(int[], int) binarySearch}.
+     */
+    private static final int[] WEIRD_CHARS =
+        {0x200C, 0x200D, 0x200E, 0x200F, 0x2028, 0x2029, 0x202A, 0x202B, 0x202C, 0x202D, 0x202E, 0x206A,
+            0x206B, 0x206C, 0x206D, 0x206E, 0x206F};
+
+    /**
+     * Resolves the character set, filters it against the TTF, writes
+     * the resulting cmap file, and returns its length in characters.
+     *
+     * @param config       parsed CLI configuration (supplies the
+     *                     charset strategy, preset, and {@code --lang}
+     *                     path)
+     * @param fontFileName filesystem path to the source TTF; used to
+     *                     open an AWT {@link java.awt.Font} for the
+     *                     {@code canDisplay} pass
+     * @param cmap         destination {@link FileHandle} for the
+     *                     generated cmap file; overwritten
+     * @return the length in characters of the written cmap content
+     *         (used by callers to pick the initial atlas size)
+     */
+    public static int build(FontwriterConfig config, String fontFileName, FileHandle cmap) {
+        FontwriterConfig.CharsetStrategy charsetStrategy = config.resolveCharsetStrategy();
+        IntSet charSet = new IntSet(65536);
+
+        if (charsetStrategy == FontwriterConfig.CharsetStrategy.PRESET) {
+            System.out.println("Building character map from predefined charset: " + config.charset + "...");
+            populateCharset(charSet, config.charset);
+        } else if (charsetStrategy == FontwriterConfig.CharsetStrategy.LANG) {
+            System.out.println("Building character map from I18N source: " + config.langPath + "...");
+            // Baseline: ASCII + extended ASCII (32–255)
+            for (int i = 32; i <= 255; i++) {
+                charSet.add(i);
+            }
+
+            // --lang accepts three forms:
+            //   1. Glob pattern  — contains * or ? → match files against the pattern
+            //   2. Single file   — path points to an existing file → read that one file
+            //   3. Folder        — path points to a directory → read all files in it
+            FileHandle[] langFiles = LangFileResolver.resolve(config.langPath);
+
+            if (langFiles != null && langFiles.length > 0) {
+                for (FileHandle f : langFiles) {
+                    try {
+                        String content = f.readString("UTF-8");
+                        for (int i = 0; i < content.length(); i++) {
+                            charSet.add(content.charAt(i));
+                        }
+                        System.out.println("  Read " + f.path() + " (" + content.length() + " chars)");
+                    } catch (Exception e) {
+                        System.err.println("Failed to read " + f.path() + ": " + e.getMessage());
+                    }
+                }
+                System.out.println("  Unique characters found: " + charSet.size);
+            } else {
+                CliMessages.printLangNoMatches(config.langPath);
+                System.exit(1);
+            }
+        } else {
+            // "all" — no --charset, no --lang: include every character in the font.
+            System.out.println("Building character map from all visible characters in the font...");
+            for (int i = 32; i < 65536; i++) {
+                charSet.add(i);
+            }
+        }
+
+        // Filter only displayable characters
+        IntArray displayableChars = new IntArray(charSet.size);
+        // If there are a lot of chars, don't report every one that this can't display.
+        boolean reasonableCharMap = charSet.size < 10000;
+        try {
+            java.awt.Font af = java.awt.Font.createFont(TRUETYPE_FONT, new File(fontFileName));
+            IntSet.IntSetIterator iter = charSet.iterator();
+            while (iter.hasNext) {
+                int code = iter.next();
+                // Skip control chars and weird formatting chars
+                if (code < 32 || (code >= 0x7F && code <= 0x9F) ||         /* C1 controls */
+                    Arrays.binarySearch(WEIRD_CHARS, code) >= 0) {
+                    continue;
+                }
+
+                if (af.canDisplay(code)) {
+                    displayableChars.add(code);
+                } else if (reasonableCharMap) {
+                    char ch = (char) code;
+                    String printable = (ch >= 32 && ch <= 126) ? String.valueOf(ch) : "\\u" + String.format("%04X", code);
+                    System.out.println("Font cannot display code " + code + " (" + printable + ")");
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+
+        // Build final string without trailing space
+        StringBuilder sb = new StringBuilder(4096);
+
+        for (int i = 0, n = displayableChars.size; i < n; i++) {
+            sb.append(displayableChars.get(i));
+            if (i + 1 < n) {
+                sb.append(' ');
+            }
+        }
+
+        cmap.writeString(sb.toString(), false, "UTF-8");
+        return sb.length();
+    }
+
+    /**
+     * Populates the given IntSet with codepoints for a predefined charset.
+     * Every set includes ASCII 32–126 as a baseline.
+     *
+     * @param charSet the set to populate (not cleared first)
+     * @param charset the predefined charset to apply
+     */
+    private static void populateCharset(IntSet charSet, FontwriterConfig.Charset charset) {
+        // ASCII baseline (32–126) — always included
+        for (int i = 32; i <= 126; i++) {
+            charSet.add(i);
+        }
+
+        switch (charset) {
+            case ASCII:
+                // Already done above
+                break;
+
+            case LATIN:
+                // Latin-1 Supplement (160–255) + Latin Extended-A (256–383)
+                for (int i = 160; i <= 383; i++) {
+                    charSet.add(i);
+                }
+                break;
+
+            case LATIN_EXT:
+                // Latin-1 Supplement (160–255) + Latin Extended-A (256–383)
+                // + Latin Extended-B (384–591) + Latin Extended Additional (7680–7935)
+                for (int i = 160; i <= 591; i++) {
+                    charSet.add(i);
+                }
+                for (int i = 7680; i <= 7935; i++) {
+                    charSet.add(i);
+                }
+                break;
+
+            case CYRILLIC:
+                // Latin (160–383) + Cyrillic (1024–1279)
+                for (int i = 160; i <= 383; i++) {
+                    charSet.add(i);
+                }
+                for (int i = 1024; i <= 1279; i++) {
+                    charSet.add(i);
+                }
+                break;
+
+            case GREEK:
+                // Latin (160–383) + Greek and Coptic (880–1023)
+                for (int i = 160; i <= 383; i++) {
+                    charSet.add(i);
+                }
+                for (int i = 880; i <= 1023; i++) {
+                    charSet.add(i);
+                }
+                break;
+
+            case ALL:
+            default:
+                for (int i = 32; i < 65536; i++) {
+                    charSet.add(i);
+                }
+                break;
+        }
+    }
+}

--- a/core/src/main/java/com/github/tommyettinger/CliMessages.java
+++ b/core/src/main/java/com/github/tommyettinger/CliMessages.java
@@ -149,8 +149,8 @@ final class CliMessages {
         System.out.println("  java -jar " + jar + " <font> <mode> <size> [WxH] [color] [langPath]");
         System.out.println();
 
-        // --- Special commands ---
-        System.out.println("Special commands:");
+        // --- Batch commands ---
+        System.out.println("Batch commands:");
         System.out.println("  --bulk [folder]      Process every .ttf/.otf in folder (default: 'input').");
         System.out.println("  --preview [folder]   Generate previews for .json fonts (default: 'fonts').");
         System.out.println("  --ubj [folder]       Convert .json fonts to .ubj + .ubj.lzma (default: 'fonts').");

--- a/core/src/main/java/com/github/tommyettinger/CliMessages.java
+++ b/core/src/main/java/com/github/tommyettinger/CliMessages.java
@@ -1,0 +1,256 @@
+package com.github.tommyettinger;
+
+import com.badlogic.gdx.utils.Os;
+
+/**
+ * All user-facing CLI messages for fontwriter: help text, version output,
+ * and error-guidance blocks for binary execution and --lang resolution
+ * failures.
+ * <p>
+ * Every method here is a pure printer — it writes to {@code System.out}
+ * or {@code System.err} and returns. None of them call {@code System.exit()};
+ * the caller decides whether to terminate.
+ * <p>
+ * Kept as a separate class so {@link Main} stays focused on the font
+ * generation pipeline rather than presentation.
+ */
+final class CliMessages {
+
+    private static final String JAR_NAME = "fontwriter-2.2.14.0.jar";
+
+    private CliMessages() {} // utility class — not instantiable
+
+    // ---------------------------------------------------------------
+    //  Help & version
+    // ---------------------------------------------------------------
+
+    /** Prints the full {@code --help} usage block to {@code System.out}. */
+    public static void printHelp() {
+        String jar = JAR_NAME;
+        System.out.println("Usage: java -jar " + jar + " <font> <mode> <size> [options]");
+        System.out.println();
+        System.out.println("Generate bitmap fonts for libGDX / TextraTypist.");
+        System.out.println();
+
+        // --- Required arguments ---
+        System.out.println("Required arguments:");
+        System.out.println("  <font>     Path to a .ttf or .otf font file (local or absolute).");
+        System.out.println();
+        System.out.println("  <mode>     Rendering mode. One of:");
+        System.out.println("               standard  — non-distance-field bitmap. Scales down well.");
+        System.out.println("                           Works everywhere including BitmapFont. (default)");
+        System.out.println("               sdf       — signed distance field. Scales up nicely; supports");
+        System.out.println("                           outline effects. Has small file sizes.");
+        System.out.println("               msdf      — multichannel SDF. Best upscaling quality, but");
+        System.out.println("                           files are large.");
+//        System.out.println("               mtsdf     — multichannel + true SDF hybrid.");
+//        System.out.println("               psdf      — pseudo SDF.");
+        System.out.println();
+        System.out.println("  <size>     Initial font size to try, in pixels (integer or decimal).");
+        System.out.println("             Recommended: 60 for most fonts. Use 200-280 for sharper");
+        System.out.println("             results (needs more atlas space). Large charsets (CJK) may");
+        System.out.println("             need 30-55 to fit within the atlas dimensions.");
+        System.out.println("             If too large, the generator retries with smaller sizes.");
+        System.out.println();
+
+        // --- Options ---
+        System.out.println("Options (can be given in any order after the required arguments):");
+        System.out.println();
+        System.out.println("  -s WxH");
+        System.out.println("  --image-size WxH   Output image dimensions.");
+        System.out.println("                     Default: 2048x2048 (or 4096x4096 for 30000+ chars).");
+        System.out.println();
+        System.out.println("  -c COLOR");
+        System.out.println("  --color COLOR      Generate an extra full-glyph preview with the given");
+        System.out.println("                     text color. Accepts named colors ('black',");
+        System.out.println("                     'dark dullest violet-blue') or hex ('#E74200').");
+        System.out.println();
+        System.out.println("  -C NAME");
+        System.out.println("  --charset NAME     Use a predefined character set instead of including");
+        System.out.println("                     every character in the font. Available sets:");
+        System.out.println("                       ascii     — Basic ASCII (32-126). English only.");
+        System.out.println("                       latin     — ASCII + Latin-1 + Latin Extended-A.");
+        System.out.println("                                   Western/Central/Eastern European.");
+        System.out.println("                       latin-ext — Latin + Extended-B + Additional.");
+        System.out.println("                                   Vietnamese, Welsh, rare romanizations.");
+        System.out.println("                       cyrillic  — Latin + Cyrillic. Russian, Ukrainian, etc.");
+        System.out.println("                       greek     — Latin + Greek.");
+        System.out.println("                       all       — Every character in the font (32-65535).");
+        System.out.println("                     Default: 'all' (every visible character in the font).");
+        System.out.println("                     Can be overridden with a specific set, or replaced");
+        System.out.println("                     entirely by using --lang instead (see below).");
+        System.out.println();
+        System.out.println("  -l PATH");
+        System.out.println("  --lang PATH        I18N source for character extraction. Accepts:");
+        System.out.println("                       Folder:  --lang i18n/de");
+        System.out.println("                         Reads all files in that folder.");
+        System.out.println("                       Pattern: --lang \"i18n/*.txt\" or --lang \"i18n/strings_*\"");
+        System.out.println("                         Matches files against the glob (* and ? wildcards).");
+        System.out.println("                       File:    --lang i18n/de/strings.properties");
+        System.out.println("                         Reads that single file.");
+        System.out.println("                     Characters found (plus ASCII 32-126 baseline) determine");
+        System.out.println("                     which glyphs to include. Only active when explicitly passed.");
+        System.out.println();
+        System.out.println("  -h");
+        System.out.println("  --help             Show this help message and exit.");
+        System.out.println();
+        System.out.println("  -v");
+        System.out.println("  --version          Show version and exit.");
+        System.out.println();
+
+        // --- Character set fallback hierarchy ---
+        System.out.println("Character set resolution (first match wins):");
+        System.out.println("  1. --charset given  -> use that predefined set.");
+        System.out.println("  2. --lang given     -> extract chars from matched files (folder, glob, or file).");
+        System.out.println("  3. neither given    -> include ALL visible characters in the font.");
+        System.out.println("  If --charset and --lang are both given, --charset takes priority.");
+        System.out.println();
+
+        // --- Examples with explanations ---
+        System.out.println("Examples:");
+        System.out.println();
+        System.out.println("  java -jar " + jar + " Gentium.ttf standard 60");
+        System.out.println("    Font: Gentium.ttf (relative path). Mode: standard (bitmap, no SDF).");
+        System.out.println("    Size: starts at 60px. Charset: all visible chars (no --charset/--lang).");
+        System.out.println("    Image: 2048x2048 (default). No extra color preview.");
+        System.out.println();
+        System.out.println("  java -jar " + jar + " MyFont.otf msdf 200 --image-size 4096x4096");
+        System.out.println("    Font: MyFont.otf. Mode: msdf. Size: starts at 200px.");
+        System.out.println("    Charset: all visible chars. Image: 4096x4096 (explicit).");
+        System.out.println("    No extra color preview.");
+        System.out.println();
+        System.out.println("  java -jar " + jar + " MyFont.otf sdf 60 --charset latin --color black");
+        System.out.println("    Font: MyFont.otf. Mode: sdf. Size: starts at 60px.");
+        System.out.println("    Charset: latin (ASCII + Latin-1 + Latin Extended-A) via --charset.");
+        System.out.println("    Image: 2048x2048 (default). Extra color preview in black.");
+        System.out.println();
+        System.out.println("  java -jar " + jar + " MyFont.otf standard 60 --lang i18n/de");
+        System.out.println("    Font: MyFont.otf. Mode: standard. Size: starts at 60px.");
+        System.out.println("    Charset: reads all files in i18n/de/, includes only characters");
+        System.out.println("    found there (plus ASCII 32-126 baseline).");
+        System.out.println("    Image: 2048x2048 (default). No extra color preview.");
+        System.out.println();
+
+        // --- Output files ---
+        System.out.println("Output files (written to fonts/ and previews/ folders):");
+        System.out.println("  fonts/<name>-<mode>.png                 Font texture atlas.");
+        System.out.println("  fonts/<name>-<mode>.json                Structured JSON font descriptor.");
+        System.out.println("  fonts/<name>-<mode>.dat                 LZB-compressed descriptor (not recommended).");
+        System.out.println("  fonts/<name>-<mode>.ubj                 UBJSON binary descriptor (smaller than .json).");
+        System.out.println("  fonts/<name>-<mode>.json.lzma           LZMA-compressed .json descriptor (recommended).");
+        System.out.println("  fonts/<name>-<mode>.ubj.lzma            LZMA-compressed .ubj descriptor (smallest).");
+        System.out.println("  previews/<name>-<mode>.png (preview)    Text rendering preview (always generated).");
+        System.out.println("  previews/full-<color>-<name>-<mode>.png Full-glyph color preview (only with --color).");
+        System.out.println("  You only need one descriptor file (.json, .dat, .ubj, etc.).");
+        System.out.println();
+
+        // --- Legacy positional syntax ---
+        System.out.println("Legacy positional syntax (DEPRECATED — will be removed in a future version):");
+        System.out.println("  java -jar " + jar + " <font> <mode> <size> [WxH] [color] [langPath]");
+        System.out.println();
+
+        // --- Special commands ---
+        System.out.println("Special commands:");
+        System.out.println("  --bulk [folder]      Process every .ttf/.otf in folder (default: 'input').");
+        System.out.println("  --preview [folder]   Generate previews for .json fonts (default: 'fonts').");
+        System.out.println("  --ubj [folder]       Convert .json fonts to .ubj + .ubj.lzma (default: 'fonts').");
+        System.out.println("  --lzma [folder]      Compress .json fonts with LZMA (default: 'fonts').");
+    }
+
+    /** Prints the version line to {@code System.out}. */
+    public static void printVersion() {
+        System.out.println("fontwriter " + JAR_NAME.replace("fontwriter-", "").replace(".jar", ""));
+    }
+
+    // ---------------------------------------------------------------
+    //  Binary execution errors
+    //  Shared guidance for msdf-atlas-gen and oxipng failures.
+    // ---------------------------------------------------------------
+
+    /**
+     * Binary not found on disk. Suggests re-extracting the distribution.
+     */
+    public static void printBinaryNotFound(String binaryName, String absolutePath) {
+        System.err.println("Error: " + binaryName + " not found at: " + absolutePath);
+        System.err.println("Make sure the fontwriter distribution is fully extracted and the distbin/ folder");
+        System.err.println("is present alongside the JAR file.");
+    }
+
+    /**
+     * Binary exists but can't be executed. Gives platform-specific guidance
+     * (chmod on macOS/Linux, Gatekeeper allow on macOS).
+     */
+    public static void printBinaryNotExecutable(String binaryName, String binaryPath,
+                                                 String absolutePath, Os os) {
+        System.err.println("Error: " + binaryName + " exists but is not executable: " + absolutePath);
+        if (os == Os.MacOsX) {
+            System.err.println("On macOS, you may need to:");
+            System.err.println("  1. Run: chmod +x " + binaryPath);
+            System.err.println("  2. Allow the binary in System Settings -> Privacy & Security -> Allow");
+            System.err.println("     (macOS may block unsigned binaries on first run)");
+        } else if (os == Os.Linux) {
+            System.err.println("On Linux, run: chmod +x " + binaryPath);
+        }
+    }
+
+    /**
+     * Binary ran but threw IOException (usually Gatekeeper or sandbox).
+     * Prints the error message plus macOS-specific Gatekeeper guidance.
+     */
+    public static void printBinaryRunFailed(String binaryName, String errorMessage, Os os) {
+        System.err.println("Error: Failed to run " + binaryName + ": " + errorMessage);
+        if (os == Os.MacOsX) {
+            System.err.println("On macOS, the binary may have been blocked by Gatekeeper.");
+            System.err.println("Open System Settings -> Privacy & Security and look for a prompt to allow it.");
+        }
+    }
+
+    /** Binary's wait() was interrupted. */
+    public static void printBinaryInterrupted(String binaryName, String errorMessage) {
+        System.err.println("Error: " + binaryName + " was interrupted: " + errorMessage);
+    }
+
+    /** Binary exited with a non-zero exit code. */
+    public static void printBinaryExitFailure(String binaryName, int exitCode) {
+        System.out.println(binaryName + " failed, returning exit code " + exitCode + "; terminating.");
+    }
+
+    // ---------------------------------------------------------------
+    //  --lang resolution errors
+    //  All emitted when resolveLangFiles() or its caller can't find
+    //  anything to read.
+    // ---------------------------------------------------------------
+
+    /**
+     * The --lang value resolved to zero files (all three modes failed).
+     * Printed from the mainProcess() lang branch.
+     */
+    public static void printLangNoMatches(String langPath) {
+        System.err.println("Error: --lang '" + langPath + "' matched no files.");
+        System.err.println("Check that the path exists and contains readable files.");
+        System.err.println("  Folder:  --lang i18n/de            (reads all files in the folder)");
+        System.err.println("  Pattern: --lang \"i18n/*.txt\"        (glob with * or ? wildcards)");
+        System.err.println("  File:    --lang i18n/strings.properties");
+    }
+
+    /** Glob mode: the directory containing the glob pattern doesn't exist. */
+    public static void printLangParentMissing(String parentPath) {
+        System.err.println("Error: parent directory '" + parentPath + "' does not exist.");
+    }
+
+    /** Glob mode: the pattern matched no files in the parent directory. */
+    public static void printLangGlobNoMatch(String globPattern, String parentDirPath) {
+        System.err.println("Error: no files matched pattern '" + globPattern
+                + "' in '" + parentDirPath + "'.");
+    }
+
+    /** Single file / folder mode: the path doesn't exist. */
+    public static void printLangPathMissing(String langPath) {
+        System.err.println("Error: --lang path '" + langPath + "' does not exist.");
+    }
+
+    /** Folder mode: the directory exists but contains no readable files. */
+    public static void printLangFolderEmpty(String langPath) {
+        System.err.println("Error: no files found in folder '" + langPath + "'.");
+    }
+}

--- a/core/src/main/java/com/github/tommyettinger/ConfigParser.java
+++ b/core/src/main/java/com/github/tommyettinger/ConfigParser.java
@@ -16,7 +16,7 @@ package com.github.tommyettinger;
  * the first three starts with "-", named-flag mode is used; otherwise
  * legacy positional mode is assumed.
  * <p>
- * Special commands ({@code --bulk}, {@code --preview}, {@code --ubj},
+ * Batch commands ({@code --bulk}, {@code --preview}, {@code --ubj},
  * {@code --lzma}) are detected first and short-circuit the rest of
  * the parsing.
  */

--- a/core/src/main/java/com/github/tommyettinger/ConfigParser.java
+++ b/core/src/main/java/com/github/tommyettinger/ConfigParser.java
@@ -56,12 +56,12 @@ public class ConfigParser {
             return config;
         }
 
-        // --- Special commands ---
-        FontwriterConfig.SpecialCommand special = FontwriterConfig.SpecialCommand.fromFlag(first);
-        if (special != null) {
-            config.specialCommand = special;
+        // --- Batch commands ---
+        FontwriterConfig.BatchCommand batch = FontwriterConfig.BatchCommand.fromFlag(first);
+        if (batch != null) {
+            config.batchCommand = batch;
             if (args.length > 1) {
-                config.specialCommandPath = args[1];
+                config.batchCommandPath = args[1];
             }
             return config;
         }

--- a/core/src/main/java/com/github/tommyettinger/ConfigParser.java
+++ b/core/src/main/java/com/github/tommyettinger/ConfigParser.java
@@ -57,9 +57,9 @@ public class ConfigParser {
         }
 
         // --- Special commands ---
-        if ("--bulk".equals(first) || "--preview".equals(first)
-                || "--ubj".equals(first) || "--lzma".equals(first)) {
-            config.specialCommand = first.substring(2); // strip "--"
+        FontwriterConfig.SpecialCommand special = FontwriterConfig.SpecialCommand.fromFlag(first);
+        if (special != null) {
+            config.specialCommand = special;
             if (args.length > 1) {
                 config.specialCommandPath = args[1];
             }

--- a/core/src/main/java/com/github/tommyettinger/FontwriterConfig.java
+++ b/core/src/main/java/com/github/tommyettinger/FontwriterConfig.java
@@ -16,7 +16,7 @@ import java.util.Locale;
  *   java -jar fontwriter.jar MyFont.otf msdf 60 --lang i18n/de --color black
  *   java -jar fontwriter.jar MyFont.otf sdf 200 --charset latin
  * </pre>
- * <b>Usage (special commands):</b>
+ * <b>Usage (batch commands):</b>
  * <pre>
  *   java -jar fontwriter.jar --bulk [folder]
  *   java -jar fontwriter.jar --preview [folder]

--- a/core/src/main/java/com/github/tommyettinger/FontwriterConfig.java
+++ b/core/src/main/java/com/github/tommyettinger/FontwriterConfig.java
@@ -174,6 +174,55 @@ public class FontwriterConfig {
     }
 
     /**
+     * Special command keywords — mutually exclusive with standard font
+     * generation. Each value owns its own CLI flag and default input
+     * folder, and is resolved from the first CLI argument by
+     * {@link #fromFlag(String)}.
+     */
+    public enum SpecialCommand {
+        /** Process every .ttf/.otf in the folder. Default folder: "input". */
+        BULK("--bulk", "input"),
+
+        /** Generate previews for .json fonts in the folder. Default: "fonts". */
+        PREVIEW("--preview", "fonts"),
+
+        /** Convert .json fonts to .ubj + .ubj.lzma. Default folder: "fonts". */
+        UBJ("--ubj", "fonts"),
+
+        /** Compress .json fonts with LZMA. Default folder: "fonts". */
+        LZMA("--lzma", "fonts");
+
+        /** The user-facing CLI flag including leading dashes (e.g. "--bulk"). */
+        public final String flag;
+
+        /** Default folder used when the user did not pass an explicit path. */
+        public final String defaultPath;
+
+        SpecialCommand(String flag, String defaultPath) {
+            this.flag = flag;
+            this.defaultPath = defaultPath;
+        }
+
+        /**
+         * Resolves a raw CLI argument to a SpecialCommand.
+         * @param arg the raw argument (e.g. "--bulk")
+         * @return the matching command, or {@code null} if {@code arg} is
+         *         not a recognized special command flag
+         */
+        public static SpecialCommand fromFlag(String arg) {
+            for (SpecialCommand c : values()) {
+                if (c.flag.equals(arg)) return c;
+            }
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return flag;
+        }
+    }
+
+    /**
      * Describes which strategy the charset resolution used.
      * See the class-level Javadoc for the fallback hierarchy.
      */
@@ -205,20 +254,27 @@ public class FontwriterConfig {
     public boolean versionRequested = false;
 
     /**
-     * Special command keyword, if any: "bulk", "preview", "ubj", or "lzma".
-     * Null when running normal font generation.
+     * Special command, if any. Null when running normal font generation.
+     * See {@link SpecialCommand} for the supported values.
      */
-    public String specialCommand = null;
+    public SpecialCommand specialCommand = null;
 
     /**
-     * Folder path used by special commands (--bulk, --preview, --ubj, --lzma).
-     * Each command has its own default if this is null:
-     *   --bulk    → "input"
-     *   --preview → "fonts"
-     *   --ubj     → "fonts"
-     *   --lzma    → "fonts"
+     * Explicit folder path for a special command. When null, the command's
+     * {@link SpecialCommand#defaultPath} is used instead. Resolve via
+     * {@link #resolveSpecialCommandPath()} rather than reading this field
+     * directly.
      */
     public String specialCommandPath = null;
+
+    /**
+     * Returns the folder path the active special command should operate on,
+     * falling back to the command's default when no explicit path was given.
+     * Must only be called when {@link #specialCommand} is non-null.
+     */
+    public String resolveSpecialCommandPath() {
+        return specialCommandPath != null ? specialCommandPath : specialCommand.defaultPath;
+    }
 
     // ---------------------------------------------------------------
     //  Required positional arguments (standard font generation).
@@ -407,7 +463,7 @@ public class FontwriterConfig {
         if (!isStandardRun()) {
             if (helpRequested) return "FontwriterConfig{--help}";
             if (versionRequested) return "FontwriterConfig{--version}";
-            return "FontwriterConfig{--" + specialCommand
+            return "FontwriterConfig{" + specialCommand
                     + (specialCommandPath != null ? " " + specialCommandPath : "")
                     + "}";
         }

--- a/core/src/main/java/com/github/tommyettinger/FontwriterConfig.java
+++ b/core/src/main/java/com/github/tommyettinger/FontwriterConfig.java
@@ -174,12 +174,12 @@ public class FontwriterConfig {
     }
 
     /**
-     * Special command keywords — mutually exclusive with standard font
+     * Batch command keywords — mutually exclusive with standard font
      * generation. Each value owns its own CLI flag and default input
      * folder, and is resolved from the first CLI argument by
      * {@link #fromFlag(String)}.
      */
-    public enum SpecialCommand {
+    public enum BatchCommand {
         /** Process every .ttf/.otf in the folder. Default folder: "input". */
         BULK("--bulk", "input"),
 
@@ -198,19 +198,19 @@ public class FontwriterConfig {
         /** Default folder used when the user did not pass an explicit path. */
         public final String defaultPath;
 
-        SpecialCommand(String flag, String defaultPath) {
+        BatchCommand(String flag, String defaultPath) {
             this.flag = flag;
             this.defaultPath = defaultPath;
         }
 
         /**
-         * Resolves a raw CLI argument to a SpecialCommand.
+         * Resolves a raw CLI argument to a BatchCommand.
          * @param arg the raw argument (e.g. "--bulk")
          * @return the matching command, or {@code null} if {@code arg} is
-         *         not a recognized special command flag
+         *         not a recognized batch command flag
          */
-        public static SpecialCommand fromFlag(String arg) {
-            for (SpecialCommand c : values()) {
+        public static BatchCommand fromFlag(String arg) {
+            for (BatchCommand c : values()) {
                 if (c.flag.equals(arg)) return c;
             }
             return null;
@@ -236,7 +236,7 @@ public class FontwriterConfig {
     }
 
     // ---------------------------------------------------------------
-    //  Special commands — mutually exclusive with standard generation.
+    //  Batch commands — mutually exclusive with standard generation.
     //  When one of these is set, the three required positional args
     //  are not needed.
     // ---------------------------------------------------------------
@@ -254,26 +254,26 @@ public class FontwriterConfig {
     public boolean versionRequested = false;
 
     /**
-     * Special command, if any. Null when running normal font generation.
-     * See {@link SpecialCommand} for the supported values.
+     * Batch command, if any. Null when running normal font generation.
+     * See {@link BatchCommand} for the supported values.
      */
-    public SpecialCommand specialCommand = null;
+    public BatchCommand batchCommand = null;
 
     /**
-     * Explicit folder path for a special command. When null, the command's
-     * {@link SpecialCommand#defaultPath} is used instead. Resolve via
-     * {@link #resolveSpecialCommandPath()} rather than reading this field
+     * Explicit folder path for a batch command. When null, the command's
+     * {@link BatchCommand#defaultPath} is used instead. Resolve via
+     * {@link #resolveBatchCommandPath()} rather than reading this field
      * directly.
      */
-    public String specialCommandPath = null;
+    public String batchCommandPath = null;
 
     /**
-     * Returns the folder path the active special command should operate on,
+     * Returns the folder path the active batch command should operate on,
      * falling back to the command's default when no explicit path was given.
-     * Must only be called when {@link #specialCommand} is non-null.
+     * Must only be called when {@link #batchCommand} is non-null.
      */
-    public String resolveSpecialCommandPath() {
-        return specialCommandPath != null ? specialCommandPath : specialCommand.defaultPath;
+    public String resolveBatchCommandPath() {
+        return batchCommandPath != null ? batchCommandPath : batchCommand.defaultPath;
     }
 
     // ---------------------------------------------------------------
@@ -401,10 +401,10 @@ public class FontwriterConfig {
 
     /**
      * Returns true when this config represents a standard font generation
-     * run (not a special command, not --help, not --version).
+     * run (not a batch command, not --help, not --version).
      */
     public boolean isStandardRun() {
-        return !helpRequested && !versionRequested && specialCommand == null;
+        return !helpRequested && !versionRequested && batchCommand == null;
     }
 
     /**
@@ -463,8 +463,8 @@ public class FontwriterConfig {
         if (!isStandardRun()) {
             if (helpRequested) return "FontwriterConfig{--help}";
             if (versionRequested) return "FontwriterConfig{--version}";
-            return "FontwriterConfig{" + specialCommand
-                    + (specialCommandPath != null ? " " + specialCommandPath : "")
+            return "FontwriterConfig{" + batchCommand
+                    + (batchCommandPath != null ? " " + batchCommandPath : "")
                     + "}";
         }
         StringBuilder sb = new StringBuilder("FontwriterConfig{");

--- a/core/src/main/java/com/github/tommyettinger/FontwriterUtils.java
+++ b/core/src/main/java/com/github/tommyettinger/FontwriterUtils.java
@@ -1,0 +1,135 @@
+package com.github.tommyettinger;
+
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.utils.JsonReader;
+import com.badlogic.gdx.utils.UBJsonWriter;
+import com.badlogic.gdx.utils.compression.Lzma;
+import com.github.tommyettinger.textra.ColorLookup;
+import com.github.tommyettinger.textra.utils.StringUtils;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Miscellaneous pure helpers used by the main font generation
+ * pipeline.
+ * <p>
+ * Everything in here is stateless and has no dependency on {@link Main}
+ * instance state, so it's grouped into one place rather than cluttering
+ * the main class with small private helpers. Each method is
+ * independently testable; collectively they cover the CLI color
+ * parsing and the JSON→UBJ/LZMA conversions that follow atlas
+ * generation.
+ */
+final class FontwriterUtils {
+
+    private FontwriterUtils() {} // utility class
+
+    /**
+     * Parses a color string from the CLI into an RGBA8888 integer.
+     * <p>
+     * Accepted forms (checked in order):
+     * <ol>
+     *   <li>A descriptive name or phrase understood by TextraTypist's
+     *       {@link ColorLookup#DESCRIPTIVE} lookup
+     *       (e.g. {@code "darker purple blue"}).</li>
+     *   <li>An HTML-style hex string with a leading {@code #} —
+     *       {@code #RGB}, {@code #RRGGBB}, or {@code #RRGGBBAA}.</li>
+     *   <li>A bare hex string — {@code RGB}, {@code RRGGBB}, or
+     *       {@code RRGGBBAA}.</li>
+     * </ol>
+     * The short 3-digit forms are expanded by duplicating each nibble
+     * (so {@code "#F3A"} becomes {@code 0xFF33AAFF}). Strings shorter
+     * than 3 characters, and {@code null}, fall through and return
+     * {@code -1} (opaque white).
+     *
+     * @param str the color string, or {@code null}
+     * @return the parsed RGBA8888 color, or {@code -1} (opaque white)
+     *         if {@code str} is {@code null}, empty, or unparseable
+     */
+    public static int stringToColor(String str) {
+        if (str != null) {
+            // Try to parse named color
+            ColorLookup lookup = ColorLookup.DESCRIPTIVE;
+            int namedColor = lookup.getRgba(str);
+            if (namedColor != 256) {
+                return namedColor;
+            }
+            // Try to parse hex
+            if (str.length() >= 3) {
+                if (str.startsWith("#")) {
+                    if (str.length() >= 9) return StringUtils.intFromHex(str, 1, 9);
+                    if (str.length() >= 7) return StringUtils.intFromHex(str, 1, 7) << 8 | 0xFF;
+                    if (str.length() >= 4) {
+                        int rgb = StringUtils.intFromHex(str, 1, 4);
+                        return
+                                (rgb << 20 & 0xF0000000) | (rgb << 16 & 0x0F000000) |
+                                        (rgb << 16 & 0x00F00000) | (rgb << 12 & 0x000F0000) |
+                                        (rgb << 12 & 0x0000F000) | (rgb <<  8 & 0x00000F00) |
+                                        0xFF;
+                    }
+                } else {
+                    if (str.length() >= 8) return StringUtils.intFromHex(str, 0, 8);
+                    if (str.length() >= 6) return StringUtils.intFromHex(str, 0, 6) << 8 | 0xFF;
+                    int rgb = StringUtils.intFromHex(str, 0, 3);
+                    return
+                            (rgb << 20 & 0xF0000000) | (rgb << 16 & 0x0F000000) |
+                                    (rgb << 16 & 0x00F00000) | (rgb << 12 & 0x000F0000) |
+                                    (rgb << 12 & 0x0000F000) | (rgb <<  8 & 0x00000F00) |
+                                    0xFF;
+                }
+            }
+        }
+
+        return -1; // white
+    }
+
+    /**
+     * Converts a JSON file to UBJSON alongside it, then LZMA-compresses
+     * the UBJSON. Given {@code foo.json} this produces {@code foo.ubj}
+     * and {@code foo.ubj.lzma} as siblings.
+     *
+     * @param inFile the source JSON file; left untouched
+     * @throws RuntimeException wrapping any {@link IOException} raised
+     *         by the UBJ or LZMA pipelines
+     */
+    public static void convertToUBJSON(FileHandle inFile) {
+        try {
+            FileHandle
+                outFile = inFile.sibling(inFile.nameWithoutExtension() + ".ubj"),
+                outLzmaFile = inFile.sibling(inFile.nameWithoutExtension() + ".ubj.lzma");
+            UBJsonWriter ubWriter = new UBJsonWriter(outFile.write(false));
+            ubWriter.value(new JsonReader().parse(inFile));
+            ubWriter.close();
+
+            BufferedInputStream bais = new BufferedInputStream(outFile.read());
+            OutputStream lzmaOut = outLzmaFile.write(false);
+            Lzma.compress(bais, lzmaOut);
+            lzmaOut.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * LZMA-compresses a JSON file alongside itself. Given
+     * {@code foo.json} this produces {@code foo.json.lzma} as a sibling.
+     *
+     * @param inFile the source JSON file; left untouched
+     * @throws RuntimeException wrapping any {@link IOException} raised
+     *         by the LZMA pipeline
+     */
+    public static void convertToLzma(FileHandle inFile) {
+        try {
+            FileHandle outLzmaFile = inFile.sibling(inFile.nameWithoutExtension() + ".json.lzma");
+
+            BufferedInputStream bais = new BufferedInputStream(inFile.read());
+            OutputStream lzmaOut = outLzmaFile.write(false);
+            Lzma.compress(bais, lzmaOut);
+            lzmaOut.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/main/java/com/github/tommyettinger/IndexedPngWriter.java
+++ b/core/src/main/java/com/github/tommyettinger/IndexedPngWriter.java
@@ -1,0 +1,187 @@
+package com.github.tommyettinger;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.utils.ByteArray;
+import com.badlogic.gdx.utils.StreamUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedOutputStream;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+
+/**
+ * Writes a libGDX {@link Pixmap} to a PNG file using an 8-bit indexed
+ * color model (a 256-entry palette plus a single byte per pixel in the
+ * IDAT stream).
+ * <p>
+ * This is a specialized encoder used by fontwriter to shrink the font
+ * atlas PNGs. The atlas is grayscale coverage data where only the
+ * alpha channel carries information, so the RGB channels can collapse
+ * into a single palette keyed by the low byte of each source pixel.
+ * The result is typically ~4x smaller than a naive RGBA PNG for the
+ * same visual output, before oxipng is even run.
+ * <p>
+ * The writer is <b>stateful</b>: internal line buffers and the
+ * {@link Deflater} are reused between calls to avoid reallocating when
+ * processing many atlases in a row (e.g. during {@code --bulk}). A
+ * single instance should be reused for the lifetime of the run. Not
+ * thread-safe — use one instance per thread.
+ */
+class IndexedPngWriter {
+
+    // PNG magic number (first 8 bytes of every PNG file).
+    private static final byte[] SIGNATURE = {(byte)137, 80, 78, 71, 13, 10, 26, 10};
+
+    // PNG chunk type identifiers (4-byte ASCII codes, big-endian).
+    private static final int IHDR = 0x49484452, IDAT = 0x49444154, IEND = 0x49454E44,
+            PLTE = 0x504C5445, TRNS = 0x74524E53;
+
+    private static final byte COLOR_INDEXED = 3;
+    private static final byte COMPRESSION_DEFLATE = 0;
+    private static final byte INTERLACE_NONE = 0;
+    private static final byte FILTER_NONE = 0;
+
+    private final ChunkBuffer buffer = new ChunkBuffer(65536);
+    private final Deflater deflater = new Deflater(0);
+    private ByteArray curLineBytes;
+    private ByteArray prevLineBytes;
+    private int lastLineLen;
+
+    /**
+     * Writes {@code pm} as an indexed PNG to {@code file}, overwriting
+     * any existing contents. Each of the 256 palette entries takes its
+     * RGB from the top 24 bits of {@code rgba}; the alpha/index byte
+     * varies 0–255. The low byte of every source pixel is used as the
+     * palette index — callers must ensure the source pixmap satisfies
+     * that assumption (fontwriter's atlas pipeline does).
+     *
+     * @param file destination file; will be overwritten
+     * @param pm   source pixmap
+     * @param rgba 32-bit color whose top 24 bits provide the palette's
+     *             shared RGB values
+     */
+    public void write(FileHandle file, Pixmap pm, int rgba) {
+        final int w = pm.getWidth(), h = pm.getHeight();
+        OutputStream output = file.write(false);
+        try {
+            DeflaterOutputStream deflaterOutput = new DeflaterOutputStream(buffer, deflater);
+            DataOutputStream dataOutput = new DataOutputStream(output);
+            try {
+                dataOutput.write(SIGNATURE);
+
+                buffer.writeInt(IHDR);
+                buffer.writeInt(w);
+                buffer.writeInt(h);
+                buffer.writeByte(8); // 8 bits per component.
+                buffer.writeByte(COLOR_INDEXED);
+                buffer.writeByte(COMPRESSION_DEFLATE);
+                buffer.writeByte(FILTER_NONE);
+                buffer.writeByte(INTERLACE_NONE);
+                buffer.endChunk(dataOutput);
+
+                buffer.writeInt(PLTE);
+                for (int i = 0; i < 256; i++) {
+                    buffer.write(rgba >>> 24);
+                    buffer.write(rgba >>> 16 & 255);
+                    buffer.write(rgba >>>  8 & 255);
+                }
+                buffer.endChunk(dataOutput);
+
+                buffer.writeInt(TRNS);
+                for (int i = 0; i < 256; i++) {
+                    buffer.write(i);
+                }
+                buffer.endChunk(dataOutput);
+
+                buffer.writeInt(IDAT);
+                deflater.reset();
+
+                int lineLen = w;
+                byte[] curLine, prevLine;
+                if (curLineBytes == null) {
+                    curLine = (curLineBytes = new ByteArray(lineLen)).items;
+                    prevLine = (prevLineBytes = new ByteArray(lineLen)).items;
+                } else {
+                    curLine = curLineBytes.ensureCapacity(lineLen);
+                    prevLine = prevLineBytes.ensureCapacity(lineLen);
+                    for (int i = 0, n = lastLineLen; i < n; i++) {
+                        prevLine[i] = 0;
+                    }
+                }
+
+                lastLineLen = lineLen;
+
+                int color;
+                boolean noWarningNeeded = false;
+                for (int y = 0; y < h; y++) {
+                    for (int x = 0; x < w; x++) {
+                        color = pm.getPixel(x, y);
+                        // this block may need to be commented out if a font uses non-white grayscale colors.
+                        if(noWarningNeeded || ((color & 255) != 0 && (color & 0xFFFFFF00) != 0xFFFFFF00)) {
+                            System.out.println("PROBLEM WITH " + file);
+                            System.out.printf("Problem color: 0x%08X\n", color);
+                            System.out.println("Position: " + x + "," + y);
+                            noWarningNeeded = true;
+                        }
+                        curLine[x] = (byte) (color & 255);
+                    }
+
+                    deflaterOutput.write(FILTER_NONE);
+                    deflaterOutput.write(curLine, 0, lineLen);
+
+                    byte[] temp = curLine;
+                    curLine = prevLine;
+                    prevLine = temp;
+                }
+                deflaterOutput.finish();
+                buffer.endChunk(dataOutput);
+
+                buffer.writeInt(IEND);
+                buffer.endChunk(dataOutput);
+
+                output.flush();
+            } catch (IOException e) {
+                Gdx.app.error("transparency", e.getMessage());
+            }
+        } finally {
+            StreamUtils.closeQuietly(output);
+        }
+    }
+
+    /**
+     * A {@link DataOutputStream} wrapping a {@link ByteArrayOutputStream}
+     * and a {@link CRC32}, used to accumulate PNG chunk payloads. On
+     * {@link #endChunk(DataOutputStream)} the wrapper writes the chunk
+     * length, the buffered payload, and the CRC to the given target
+     * stream, then resets both the buffer and the CRC for the next chunk.
+     */
+    private static class ChunkBuffer extends DataOutputStream {
+        final ByteArrayOutputStream buffer;
+        final CRC32 crc;
+
+        ChunkBuffer(int initialSize) {
+            this(new ByteArrayOutputStream(initialSize), new CRC32());
+        }
+
+        private ChunkBuffer(ByteArrayOutputStream buffer, CRC32 crc) {
+            super(new CheckedOutputStream(buffer, crc));
+            this.buffer = buffer;
+            this.crc = crc;
+        }
+
+        public void endChunk(DataOutputStream target) throws IOException {
+            flush();
+            target.writeInt(buffer.size() - 4);
+            buffer.writeTo(target);
+            target.writeInt((int) crc.getValue());
+            buffer.reset();
+            crc.reset();
+        }
+    }
+}

--- a/core/src/main/java/com/github/tommyettinger/LangFileResolver.java
+++ b/core/src/main/java/com/github/tommyettinger/LangFileResolver.java
@@ -1,0 +1,101 @@
+package com.github.tommyettinger;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+
+/**
+ * Resolves the {@code --lang} CLI value into an array of files whose
+ * contents are then scanned to build the font's character map.
+ * <p>
+ * Three input modes are supported:
+ * <ol>
+ *   <li><b>Glob pattern</b> (contains {@code *} or {@code ?}) — the
+ *       parent directory is listed and filenames are matched against
+ *       the glob portion, e.g. {@code "i18n/*.txt"} or
+ *       {@code "i18n/*"}.</li>
+ *   <li><b>Single file</b> — the path points to an existing file; an
+ *       array with just that file is returned.</li>
+ *   <li><b>Folder</b> — the path points to an existing directory; all
+ *       non-hidden files inside it are returned. Equivalent to passing
+ *       the folder with {@code "/*"}.</li>
+ * </ol>
+ * User-facing diagnostics for missing paths, empty folders, and
+ * unmatched globs are routed through {@link CliMessages}. On any of
+ * those failures the returned array is either {@code null} or empty,
+ * and the caller is expected to fall back to a default charset.
+ */
+final class LangFileResolver {
+
+    private LangFileResolver() {} // utility class
+
+    /**
+     * Resolves the {@code --lang} value into an array of files to read.
+     *
+     * @param langPath the raw {@code --lang} value from the user
+     * @return matched files, or {@code null}/empty if nothing was found
+     */
+    public static FileHandle[] resolve(String langPath) {
+        // --- Mode 1: Glob pattern (contains * or ?) ---
+        if (langPath.contains("*") || langPath.contains("?")) {
+            // Split into parent directory + filename pattern.
+            // e.g. "i18n/*.txt" → parent="i18n", pattern="*.txt"
+            // e.g. "i18n/*"          → parent="i18n", pattern="*"
+            int lastSep = Math.max(langPath.lastIndexOf('/'), langPath.lastIndexOf('\\'));
+            String parentPath;
+            String globPattern;
+            if (lastSep >= 0) {
+                parentPath = langPath.substring(0, lastSep);
+                globPattern = langPath.substring(lastSep + 1);
+            } else {
+                parentPath = ".";
+                globPattern = langPath;
+            }
+
+            FileHandle parentDir = Gdx.files.absolute(parentPath);
+            if (!parentDir.exists()) parentDir = Gdx.files.local(parentPath);
+            if (!parentDir.exists() || !parentDir.isDirectory()) {
+                CliMessages.printLangParentMissing(parentPath);
+                return null;
+            }
+
+            // Convert glob to regex: escape dots, * → .*, ? → .
+            final String regex = "^" + globPattern
+                    .replace(".", "\\.")
+                    .replace("*", ".*")
+                    .replace("?", ".")
+                    + "$";
+
+            FileHandle[] matched = parentDir.list((d, name) -> name.matches(regex));
+            if (matched == null || matched.length == 0) {
+                CliMessages.printLangGlobNoMatch(globPattern, parentDir.path());
+            } else {
+                System.out.println("  Matched " + matched.length + " file(s) from pattern '" + langPath + "'.");
+            }
+            return matched;
+        }
+
+        // --- Mode 2 & 3: resolve as absolute or local path ---
+        FileHandle resolved = Gdx.files.absolute(langPath);
+        if (!resolved.exists()) resolved = Gdx.files.local(langPath);
+
+        if (!resolved.exists()) {
+            CliMessages.printLangPathMissing(langPath);
+            return null;
+        }
+
+        // --- Mode 2: Single file ---
+        if (!resolved.isDirectory()) {
+            System.out.println("  Using single file: " + resolved.path());
+            return new FileHandle[]{resolved};
+        }
+
+        // --- Mode 3: Folder — read all files in the directory ---
+        FileHandle[] langFiles = resolved.list((d, name) -> !name.startsWith("."));
+        if (langFiles == null || langFiles.length == 0) {
+            CliMessages.printLangFolderEmpty(langPath);
+        } else {
+            System.out.println("  Found " + langFiles.length + " file(s) in folder '" + langPath + "'.");
+        }
+        return langFiles;
+    }
+}

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -4,16 +4,10 @@ import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.*;
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.utils.*;
-import com.github.tommyettinger.textra.Font;
-import com.github.tommyettinger.textra.Layout;
 import com.github.tommyettinger.textra.utils.LZBCompression;
 
 import java.io.*;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,20 +16,7 @@ public class Main extends ApplicationAdapter {
 
     private final IndexedPngWriter indexedPngWriter = new IndexedPngWriter();
     private FontwriterConfig config;
-
-    private SpriteBatch batch;
-
-    private final Layout layout = new Layout().setTargetWidth(1200);
-    private static final String text = "Fonts can be rendered normally,{CURLY BRACKETS ARE IGNORED} but using [[tags], you can..."
-            + "\n[#E74200]...use CSS-style hex colors like [*]#E74200[*]..."
-            + "\n[darker purple blue]...use color names or descriptions, like [/]darker purple blue[/]...[ ]"
-            + "\n[_]...and use [!]effects[!][_]!"
-            + "\nNormal, [*]bold[*], [/]oblique[/] (like italic), [*][/]bold oblique[ ],"
-            + "\n[_]underline (even for multiple words)[_], [~]strikethrough (same)[ ],"
-            + "\nscaling: [%50]very [%75]small [%100]to [%150]quite [%200]large[ ], notes: [.]sub-[.], [=]mid-[=], and [^]super-[^]script,"
-            + "\ncapitalization changes: [;]Each cap, [,]All lower, [!]Caps lock[ ],"
-            + "\n[?small caps][*]Special[*][?] [?whiten][/]Effects[/][?][#]: [?shadow]drop shadow[?], [?jostle]RaNsoM nOtE[?], [?error]spell check[?]..."
-            + "\nWelcome to the [TEAL][?neon]Structured JSON Zone[ ]!";
+    private PreviewRenderer previewRenderer;
 
     String archPath, atlasGenBinary, oxipngBinary = "oxipng";
 
@@ -76,7 +57,7 @@ public class Main extends ApplicationAdapter {
 
     @Override
     public void create() {
-        batch = new SpriteBatch();
+        previewRenderer = new PreviewRenderer(archPath, oxipngBinary);
         Gdx.files.local("fonts").mkdirs();
         Gdx.files.local("previews").mkdirs();
 
@@ -129,7 +110,7 @@ public class Main extends ApplicationAdapter {
                     previewConfig.fontPath = filePath;
                     previewConfig.mode = FontwriterConfig.Mode.fromString(fileMode);
                     this.config = previewConfig;
-                    makePreview(inPath + "/", fontName);
+                    previewRenderer.render(config, inPath + "/", fontName);
                 }
                 break;
             }
@@ -252,7 +233,7 @@ public class Main extends ApplicationAdapter {
             System.out.println("Running command: " + String.join(" ", oxiCmd));
             BinaryExec.runOrExit(archPath + oxipngBinary, "oxipng", oxiCmd, workingDir);
         }
-        makePreview("fonts/", fontName);
+        previewRenderer.render(config, "fonts/", fontName);
 
         // --- Summary: list all generated files with full paths ---
         System.out.println();
@@ -275,57 +256,6 @@ public class Main extends ApplicationAdapter {
                 System.out.println("  " + colorPreview.file().getAbsolutePath());
             }
         }
-    }
-
-    private void makePreview(String inPath, String fontName) {
-        FontwriterConfig.Mode mode = config.mode;
-        System.out.println("Creating a preview for " + fontName + "-" + mode + "...");
-        Texture fontTexture = new Texture(inPath+fontName+"-"+mode+".png");
-        Font font = new Font(inPath+fontName+"-"+mode+".json",
-                new TextureRegion(fontTexture), 0f, 0f, 0f, 0f,
-                true, true);
-        if(fontTexture.getWidth() >= 1024 && fontTexture.getHeight() >= 1024)
-            font.scaleHeightTo(32f);
-        else
-            font.scale(Math.round(512f / fontTexture.getHeight()))
-                .setTextureFilter(Texture.TextureFilter.Nearest, Texture.TextureFilter.Nearest)
-                .useIntegerPositions(true); // for pixel fonts
-        font.resizeDistanceField(Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-
-        layout.setBaseColor(Color.DARK_GRAY);
-        layout.setMaxLines(20);
-        layout.setEllipsis(" and so on and so forth...");
-        font.markup(text, layout);
-
-        ScreenUtils.clear(0.75f, 0.75f, 0.75f, 1f);
-        float x = Gdx.graphics.getBackBufferWidth() * 0.5f;
-        float y = (Gdx.graphics.getBackBufferHeight() + layout.getHeight()) * 0.5f;
-        batch.begin();
-        font.enableShader(batch);
-        font.drawGlyphs(batch, layout, x, y, Align.center);
-        batch.end();
-
-        // Modified Pixmap.createFromFrameBuffer() code that uses RGB instead of RGBA
-        Gdx.gl.glPixelStorei(GL20.GL_PACK_ALIGNMENT, 1);
-        final Pixmap pm = new Pixmap(Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), Pixmap.Format.RGB888);
-        ByteBuffer pixels = pm.getPixels();
-        Gdx.gl.glReadPixels(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, pixels);
-        // End Pixmap.createFromFrameBuffer() modified code
-
-        FileHandle previewFile = Gdx.files.local("previews/" + fontName+"-"+mode + ".png");
-        PixmapIO.writePNG(previewFile, pm, 0, true);
-
-        List<String> oxiCmd = new ArrayList<>();
-        oxiCmd.add(archPath + oxipngBinary);
-        oxiCmd.add("-o");
-        oxiCmd.add("6");
-        oxiCmd.add("--ng");
-        oxiCmd.add("-s");
-        oxiCmd.add(previewFile.path());
-
-        System.out.println("Running command: " + String.join(" ", oxiCmd));
-        BinaryExec.runOrExit(archPath + oxipngBinary, "oxipng", oxiCmd,
-                new File(Gdx.files.getLocalStoragePath()));
     }
 
     /**

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -31,8 +31,6 @@ import static java.awt.Font.TRUETYPE_FONT;
 /** {@link com.badlogic.gdx.ApplicationListener} implementation shared by all platforms. */
 public class Main extends ApplicationAdapter {
 
-    private static final String JAR_NAME = "fontwriter-2.2.14.0.jar";
-
     static private final byte[] SIGNATURE = {(byte)137, 80, 78, 71, 13, 10, 26, 10};
     static private final int IHDR = 0x49484452, IDAT = 0x49444154, IEND = 0x49454E44,
             PLTE = 0x504C5445, TRNS = 0x74524E53;
@@ -73,12 +71,12 @@ public class Main extends ApplicationAdapter {
         }
 
         if (config.helpRequested) {
-            printHelp();
+            CliMessages.printHelp();
             System.exit(0);
         }
 
         if (config.versionRequested) {
-            System.out.println("fontwriter " + JAR_NAME.replace("fontwriter-", "").replace(".jar", ""));
+            CliMessages.printVersion();
             System.exit(0);
         }
 
@@ -99,137 +97,6 @@ public class Main extends ApplicationAdapter {
 
     }
 
-    private void printHelp() {
-        String jar = JAR_NAME;
-        System.out.println("Usage: java -jar " + jar + " <font> <mode> <size> [options]");
-        System.out.println();
-        System.out.println("Generate bitmap fonts for libGDX / TextraTypist.");
-        System.out.println();
-
-        // --- Required arguments ---
-        System.out.println("Required arguments:");
-        System.out.println("  <font>     Path to a .ttf or .otf font file (local or absolute).");
-        System.out.println();
-        System.out.println("  <mode>     Rendering mode. One of:");
-        System.out.println("               standard  — non-distance-field bitmap. Scales down well.");
-        System.out.println("                           Works everywhere including BitmapFont. (default)");
-        System.out.println("               sdf       — signed distance field. Scales up nicely; supports");
-        System.out.println("                           outline effects. Has small file sizes.");
-        System.out.println("               msdf      — multichannel SDF. Best upscaling quality, but");
-        System.out.println("                           files are large.");
-//        System.out.println("               mtsdf     — multichannel + true SDF hybrid.");
-//        System.out.println("               psdf      — pseudo SDF.");
-        System.out.println();
-        System.out.println("  <size>     Initial font size to try, in pixels (integer or decimal).");
-        System.out.println("             Recommended: 60 for most fonts. Use 200-280 for sharper");
-        System.out.println("             results (needs more atlas space). Large charsets (CJK) may");
-        System.out.println("             need 30-55 to fit within the atlas dimensions.");
-        System.out.println("             If too large, the generator retries with smaller sizes.");
-        System.out.println();
-
-        // --- Options ---
-        System.out.println("Options (can be given in any order after the required arguments):");
-        System.out.println();
-        System.out.println("  -s WxH");
-        System.out.println("  --image-size WxH   Output image dimensions.");
-        System.out.println("                     Default: 2048x2048 (or 4096x4096 for 30000+ chars).");
-        System.out.println();
-        System.out.println("  -c COLOR");
-        System.out.println("  --color COLOR      Generate an extra full-glyph preview with the given");
-        System.out.println("                     text color. Accepts named colors ('black',");
-        System.out.println("                     'dark dullest violet-blue') or hex ('#E74200').");
-        System.out.println();
-        System.out.println("  -C NAME");
-        System.out.println("  --charset NAME     Use a predefined character set instead of including");
-        System.out.println("                     every character in the font. Available sets:");
-        System.out.println("                       ascii     — Basic ASCII (32-126). English only.");
-        System.out.println("                       latin     — ASCII + Latin-1 + Latin Extended-A.");
-        System.out.println("                                   Western/Central/Eastern European.");
-        System.out.println("                       latin-ext — Latin + Extended-B + Additional.");
-        System.out.println("                                   Vietnamese, Welsh, rare romanizations.");
-        System.out.println("                       cyrillic  — Latin + Cyrillic. Russian, Ukrainian, etc.");
-        System.out.println("                       greek     — Latin + Greek.");
-        System.out.println("                       all       — Every character in the font (32-65535).");
-        System.out.println("                     Default: 'all' (every visible character in the font).");
-        System.out.println("                     Can be overridden with a specific set, or replaced");
-        System.out.println("                     entirely by using --lang instead (see below).");
-        System.out.println();
-        System.out.println("  -l PATH");
-        System.out.println("  --lang PATH        I18N source for character extraction. Accepts:");
-        System.out.println("                       Folder:  --lang i18n/de");
-        System.out.println("                         Reads all files in that folder.");
-        System.out.println("                       Pattern: --lang \"i18n/*.txt\" or --lang \"i18n/strings_*\"");
-        System.out.println("                         Matches files against the glob (* and ? wildcards).");
-        System.out.println("                       File:    --lang i18n/de/strings.properties");
-        System.out.println("                         Reads that single file.");
-        System.out.println("                     Characters found (plus ASCII 32-126 baseline) determine");
-        System.out.println("                     which glyphs to include. Only active when explicitly passed.");
-        System.out.println();
-        System.out.println("  -h");
-        System.out.println("  --help             Show this help message and exit.");
-        System.out.println();
-        System.out.println("  -v");
-        System.out.println("  --version          Show version and exit.");
-        System.out.println();
-
-        // --- Character set fallback hierarchy ---
-        System.out.println("Character set resolution (first match wins):");
-        System.out.println("  1. --charset given  -> use that predefined set.");
-        System.out.println("  2. --lang given     -> extract chars from matched files (folder, glob, or file).");
-        System.out.println("  3. neither given    -> include ALL visible characters in the font.");
-        System.out.println("  If --charset and --lang are both given, --charset takes priority.");
-        System.out.println();
-
-        // --- Examples with explanations ---
-        System.out.println("Examples:");
-        System.out.println();
-        System.out.println("  java -jar " + jar + " Gentium.ttf standard 60");
-        System.out.println("    Font: Gentium.ttf (relative path). Mode: standard (bitmap, no SDF).");
-        System.out.println("    Size: starts at 60px. Charset: all visible chars (no --charset/--lang).");
-        System.out.println("    Image: 2048x2048 (default). No extra color preview.");
-        System.out.println();
-        System.out.println("  java -jar " + jar + " MyFont.otf msdf 200 --image-size 4096x4096");
-        System.out.println("    Font: MyFont.otf. Mode: msdf. Size: starts at 200px.");
-        System.out.println("    Charset: all visible chars. Image: 4096x4096 (explicit).");
-        System.out.println("    No extra color preview.");
-        System.out.println();
-        System.out.println("  java -jar " + jar + " MyFont.otf sdf 60 --charset latin --color black");
-        System.out.println("    Font: MyFont.otf. Mode: sdf. Size: starts at 60px.");
-        System.out.println("    Charset: latin (ASCII + Latin-1 + Latin Extended-A) via --charset.");
-        System.out.println("    Image: 2048x2048 (default). Extra color preview in black.");
-        System.out.println();
-        System.out.println("  java -jar " + jar + " MyFont.otf standard 60 --lang i18n/de");
-        System.out.println("    Font: MyFont.otf. Mode: standard. Size: starts at 60px.");
-        System.out.println("    Charset: reads all files in i18n/de/, includes only characters");
-        System.out.println("    found there (plus ASCII 32-126 baseline).");
-        System.out.println("    Image: 2048x2048 (default). No extra color preview.");
-        System.out.println();
-
-        // --- Output files ---
-        System.out.println("Output files (written to fonts/ and previews/ folders):");
-        System.out.println("  fonts/<name>-<mode>.png                 Font texture atlas.");
-        System.out.println("  fonts/<name>-<mode>.json                Structured JSON font descriptor.");
-        System.out.println("  fonts/<name>-<mode>.dat                 LZB-compressed descriptor (not recommended).");
-        System.out.println("  fonts/<name>-<mode>.ubj                 UBJSON binary descriptor (smaller than .json).");
-        System.out.println("  fonts/<name>-<mode>.json.lzma           LZMA-compressed .json descriptor (recommended).");
-        System.out.println("  fonts/<name>-<mode>.ubj.lzma            LZMA-compressed .ubj descriptor (smallest).");
-        System.out.println("  previews/<name>-<mode>.png (preview)    Text rendering preview (always generated).");
-        System.out.println("  previews/full-<color>-<name>-<mode>.png Full-glyph color preview (only with --color).");
-        System.out.println("  You only need one descriptor file (.json, .dat, .ubj, etc.).");
-        System.out.println();
-
-        // --- Legacy positional syntax ---
-        System.out.println("Legacy positional syntax (DEPRECATED — will be removed in a future version):");
-        System.out.println("  java -jar " + jar + " <font> <mode> <size> [WxH] [color] [langPath]");
-        System.out.println();
-
-        // --- Special commands ---
-        System.out.println("Special commands:");
-        System.out.println("  --bulk [folder]      Process every .ttf/.otf in folder (default: 'input').");
-        System.out.println("  --preview [folder]   Generate previews for .json fonts (default: 'fonts').");
-        System.out.println("  --ubj [folder]       Convert .json fonts to .ubj + .ubj.lzma (default: 'fonts').");
-        System.out.println("  --lzma [folder]      Compress .json fonts with LZMA (default: 'fonts').");
-    }
     @Override
     public void create() {
         batch = new SpriteBatch();
@@ -313,21 +180,12 @@ public class Main extends ApplicationAdapter {
     private void verifyBinary(String binaryPath, String binaryName) {
         File binaryFile = new File(Gdx.files.getLocalStoragePath(), binaryPath);
         if (!binaryFile.exists()) {
-            System.err.println("Error: " + binaryName + " not found at: " + binaryFile.getAbsolutePath());
-            System.err.println("Make sure the fontwriter distribution is fully extracted and the distbin/ folder");
-            System.err.println("is present alongside the JAR file.");
+            CliMessages.printBinaryNotFound(binaryName, binaryFile.getAbsolutePath());
             System.exit(1);
         }
         if (!binaryFile.canExecute()) {
-            System.err.println("Error: " + binaryName + " exists but is not executable: " + binaryFile.getAbsolutePath());
-            if (SharedLibraryLoader.os == Os.MacOsX) {
-                System.err.println("On macOS, you may need to:");
-                System.err.println("  1. Run: chmod +x " + binaryPath);
-                System.err.println("  2. Allow the binary in System Settings -> Privacy & Security -> Allow");
-                System.err.println("     (macOS may block unsigned binaries on first run)");
-            } else if (SharedLibraryLoader.os == Os.Linux) {
-                System.err.println("On Linux, run: chmod +x " + binaryPath);
-            }
+            CliMessages.printBinaryNotExecutable(binaryName, binaryPath,
+                    binaryFile.getAbsolutePath(), SharedLibraryLoader.os);
             System.exit(1);
         }
     }
@@ -386,11 +244,7 @@ public class Main extends ApplicationAdapter {
                 }
                 System.out.println("  Unique characters found: " + charSet.size);
             } else {
-                System.err.println("Error: --lang '" + config.langPath + "' matched no files.");
-                System.err.println("Check that the path exists and contains readable files.");
-                System.err.println("  Folder:  --lang i18n/de            (reads all files in the folder)");
-                System.err.println("  Pattern: --lang \"i18n/*.txt\"        (glob with * or ? wildcards)");
-                System.err.println("  File:    --lang i18n/strings.properties");
+                CliMessages.printLangNoMatches(config.langPath);
                 System.exit(1);
             }
         } else {
@@ -507,15 +361,11 @@ public class Main extends ApplicationAdapter {
                     break;
                 }
             } catch (IOException e) {
-                System.err.println("Error: Failed to run msdf-atlas-gen: " + e.getMessage());
-                if (SharedLibraryLoader.os == Os.MacOsX) {
-                    System.err.println("On macOS, the binary may have been blocked by Gatekeeper.");
-                    System.err.println("Open System Settings -> Privacy & Security and look for a prompt to allow it.");
-                }
+                CliMessages.printBinaryRunFailed("msdf-atlas-gen", e.getMessage(), SharedLibraryLoader.os);
                 System.exit(1);
                 break;
             } catch (InterruptedException e) {
-                System.err.println("Error: msdf-atlas-gen was interrupted: " + e.getMessage());
+                CliMessages.printBinaryInterrupted("msdf-atlas-gen", e.getMessage());
                 System.exit(1);
                 break;
             }
@@ -555,18 +405,14 @@ public class Main extends ApplicationAdapter {
         try {
             int exitCode = builder.start().waitFor();
             if (exitCode != 0) {
-                System.out.println("oxipng failed, returning exit code " + exitCode + "; terminating.");
+                CliMessages.printBinaryExitFailure("oxipng", exitCode);
                 System.exit(exitCode);
             }
         } catch (IOException e) {
-            System.err.println("Error: Failed to run oxipng: " + e.getMessage());
-            if (SharedLibraryLoader.os == Os.MacOsX) {
-                System.err.println("On macOS, the binary may have been blocked by Gatekeeper.");
-                System.err.println("Open System Settings -> Privacy & Security and look for a prompt to allow it.");
-            }
+            CliMessages.printBinaryRunFailed("oxipng", e.getMessage(), SharedLibraryLoader.os);
             System.exit(1);
         } catch (InterruptedException e) {
-            System.err.println("Error: oxipng was interrupted: " + e.getMessage());
+            CliMessages.printBinaryInterrupted("oxipng", e.getMessage());
             System.exit(1);
         }
         if (fullPreview) {
@@ -576,18 +422,14 @@ public class Main extends ApplicationAdapter {
             try {
                 int exitCode = builder.start().waitFor();
                 if (exitCode != 0) {
-                    System.out.println("oxipng failed, returning exit code " + exitCode + "; terminating.");
+                    CliMessages.printBinaryExitFailure("oxipng", exitCode);
                     System.exit(exitCode);
                 }
             } catch (IOException e) {
-                System.err.println("Error: Failed to run oxipng: " + e.getMessage());
-                if (SharedLibraryLoader.os == Os.MacOsX) {
-                    System.err.println("On macOS, the binary may have been blocked by Gatekeeper.");
-                    System.err.println("Open System Settings -> Privacy & Security and look for a prompt to allow it.");
-                }
+                CliMessages.printBinaryRunFailed("oxipng", e.getMessage(), SharedLibraryLoader.os);
                 System.exit(1);
             } catch (InterruptedException e) {
-                System.err.println("Error: oxipng was interrupted: " + e.getMessage());
+                CliMessages.printBinaryInterrupted("oxipng", e.getMessage());
                 System.exit(1);
             }
 
@@ -655,7 +497,7 @@ public class Main extends ApplicationAdapter {
             FileHandle parentDir = Gdx.files.absolute(parentPath);
             if (!parentDir.exists()) parentDir = Gdx.files.local(parentPath);
             if (!parentDir.exists() || !parentDir.isDirectory()) {
-                System.err.println("Error: parent directory '" + parentPath + "' does not exist.");
+                CliMessages.printLangParentMissing(parentPath);
                 return null;
             }
 
@@ -668,8 +510,7 @@ public class Main extends ApplicationAdapter {
 
             FileHandle[] matched = parentDir.list((d, name) -> name.matches(regex));
             if (matched == null || matched.length == 0) {
-                System.err.println("Error: no files matched pattern '" + globPattern
-                        + "' in '" + parentDir.path() + "'.");
+                CliMessages.printLangGlobNoMatch(globPattern, parentDir.path());
             } else {
                 System.out.println("  Matched " + matched.length + " file(s) from pattern '" + langPath + "'.");
             }
@@ -681,7 +522,7 @@ public class Main extends ApplicationAdapter {
         if (!resolved.exists()) resolved = Gdx.files.local(langPath);
 
         if (!resolved.exists()) {
-            System.err.println("Error: --lang path '" + langPath + "' does not exist.");
+            CliMessages.printLangPathMissing(langPath);
             return null;
         }
 
@@ -694,7 +535,7 @@ public class Main extends ApplicationAdapter {
         // --- Mode 3: Folder — read all files in the directory ---
         FileHandle[] langFiles = resolved.list((d, name) -> !name.startsWith("."));
         if (langFiles == null || langFiles.length == 0) {
-            System.err.println("Error: no files found in folder '" + langPath + "'.");
+            CliMessages.printLangFolderEmpty(langPath);
         } else {
             System.out.println("  Found " + langFiles.length + " file(s) in folder '" + langPath + "'.");
         }
@@ -823,18 +664,14 @@ public class Main extends ApplicationAdapter {
         try {
             int exitCode = builder.start().waitFor();
             if (exitCode != 0) {
-                System.out.println("oxipng failed, returning exit code " + exitCode + "; terminating.");
+                CliMessages.printBinaryExitFailure("oxipng", exitCode);
                 System.exit(exitCode);
             }
         } catch (IOException e) {
-            System.err.println("Error: Failed to run oxipng: " + e.getMessage());
-            if (SharedLibraryLoader.os == Os.MacOsX) {
-                System.err.println("On macOS, the binary may have been blocked by Gatekeeper.");
-                System.err.println("Open System Settings -> Privacy & Security and look for a prompt to allow it.");
-            }
+            CliMessages.printBinaryRunFailed("oxipng", e.getMessage(), SharedLibraryLoader.os);
             System.exit(1);
         } catch (InterruptedException e) {
-            System.err.println("Error: oxipng was interrupted: " + e.getMessage());
+            CliMessages.printBinaryInterrupted("oxipng", e.getMessage());
             System.exit(1);
         }
     }

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -83,6 +83,7 @@ public class Main extends ApplicationAdapter {
             mainProcess();
         }
 
+        previewRenderer.dispose();
         Gdx.app.exit();
     }
 

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -19,7 +19,7 @@ import java.util.List;
  * pick the correct {@code distbin/} directory for the bundled
  * msdf-atlas-gen and oxipng binaries, and then — once libGDX has
  * created a GL context in {@link #create()} — either dispatches to
- * {@link #runSpecialCommand()} (for {@code --bulk}, {@code --preview},
+ * {@link #runBatchCommand()} (for {@code --bulk}, {@code --preview},
  * {@code --ubj}, {@code --lzma}) or runs {@link #mainProcess()} once
  * for the single font requested on the command line.
  * <p>
@@ -77,8 +77,8 @@ public class Main extends ApplicationAdapter {
         Gdx.files.local("fonts").mkdirs();
         Gdx.files.local("previews").mkdirs();
 
-        if (config.specialCommand != null) {
-            runSpecialCommand();
+        if (config.batchCommand != null) {
+            runBatchCommand();
         } else {
             mainProcess();
         }
@@ -86,9 +86,9 @@ public class Main extends ApplicationAdapter {
         Gdx.app.exit();
     }
 
-    private void runSpecialCommand() {
-        FontwriterConfig.SpecialCommand command = config.specialCommand;
-        String inPath = config.resolveSpecialCommandPath();
+    private void runBatchCommand() {
+        FontwriterConfig.BatchCommand command = config.batchCommand;
+        String inPath = config.resolveBatchCommandPath();
 
         switch (command) {
             case BULK: {

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -21,29 +21,13 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.zip.CRC32;
-import java.util.zip.CheckedOutputStream;
-import java.util.zip.Deflater;
-import java.util.zip.DeflaterOutputStream;
 
 import static java.awt.Font.TRUETYPE_FONT;
 
 /** {@link com.badlogic.gdx.ApplicationListener} implementation shared by all platforms. */
 public class Main extends ApplicationAdapter {
 
-    static private final byte[] SIGNATURE = {(byte)137, 80, 78, 71, 13, 10, 26, 10};
-    static private final int IHDR = 0x49484452, IDAT = 0x49444154, IEND = 0x49454E44,
-            PLTE = 0x504C5445, TRNS = 0x74524E53;
-    static private final byte COLOR_INDEXED = 3;
-    static private final byte COMPRESSION_DEFLATE = 0;
-    static private final byte INTERLACE_NONE = 0;
-    static private final byte FILTER_NONE = 0;
-
-    private final ChunkBuffer buffer = new ChunkBuffer(65536);
-    private final Deflater deflater = new Deflater(0);
-    private ByteArray curLineBytes;
-    private ByteArray prevLineBytes;
-    private int lastLineLen;
+    private final IndexedPngWriter indexedPngWriter = new IndexedPngWriter();
     private FontwriterConfig config;
 
     private SpriteBatch batch;
@@ -780,115 +764,7 @@ public class Main extends ApplicationAdapter {
             return;
         }
 
-        OutputStream output = file.write(false);
-        try {
-            DeflaterOutputStream deflaterOutput = new DeflaterOutputStream(buffer, deflater);
-            DataOutputStream dataOutput = new DataOutputStream(output);
-            try {
-                dataOutput.write(SIGNATURE);
-
-                buffer.writeInt(IHDR);
-                buffer.writeInt(pm.getWidth());
-                buffer.writeInt(pm.getHeight());
-                buffer.writeByte(8); // 8 bits per component.
-                buffer.writeByte(COLOR_INDEXED);
-                buffer.writeByte(COMPRESSION_DEFLATE);
-                buffer.writeByte(FILTER_NONE);
-                buffer.writeByte(INTERLACE_NONE);
-                buffer.endChunk(dataOutput);
-
-                buffer.writeInt(PLTE);
-                for (int i = 0; i < 256; i++) {
-                    buffer.write(rgba >>> 24);
-                    buffer.write(rgba >>> 16 & 255);
-                    buffer.write(rgba >>>  8 & 255);
-                }
-                buffer.endChunk(dataOutput);
-
-                buffer.writeInt(TRNS);
-
-                for (int i = 0; i < 256; i++) {
-                    buffer.write(i);
-                }
-
-                buffer.endChunk(dataOutput);
-                buffer.writeInt(IDAT);
-                deflater.reset();
-
-                int lineLen = pm.getWidth();
-                byte[] curLine, prevLine;
-                if (curLineBytes == null) {
-                    curLine = (curLineBytes = new ByteArray(lineLen)).items;
-                    prevLine = (prevLineBytes = new ByteArray(lineLen)).items;
-                } else {
-                    curLine = curLineBytes.ensureCapacity(lineLen);
-                    prevLine = prevLineBytes.ensureCapacity(lineLen);
-                    for (int i = 0, n = lastLineLen; i < n; i++) {
-                        prevLine[i] = 0;
-                    }
-                }
-
-                lastLineLen = lineLen;
-
-                int color;
-                boolean noWarningNeeded = false;
-                for (int y = 0; y < h; y++) {
-                    for (int x = 0; x < w; x++) {
-                        color = pm.getPixel(x, y);
-                        // this block may need to be commented out if a font uses non-white grayscale colors.
-                        if(noWarningNeeded || ((color & 255) != 0 && (color & 0xFFFFFF00) != 0xFFFFFF00)) {
-                            System.out.println("PROBLEM WITH " + file);
-                            System.out.printf("Problem color: 0x%08X\n", color);
-                            System.out.println("Position: " + x + "," + y);
-                            noWarningNeeded = true;
-                        }
-                        curLine[x] = (byte) (color & 255);
-                    }
-
-                    deflaterOutput.write(FILTER_NONE);
-                    deflaterOutput.write(curLine, 0, lineLen);
-
-                    byte[] temp = curLine;
-                    curLine = prevLine;
-                    prevLine = temp;
-                }
-                deflaterOutput.finish();
-                buffer.endChunk(dataOutput);
-
-                buffer.writeInt(IEND);
-                buffer.endChunk(dataOutput);
-
-                output.flush();
-            } catch (IOException e) {
-                Gdx.app.error("transparency", e.getMessage());
-            }
-        } finally {
-            StreamUtils.closeQuietly(output);
-        }
-    }
-
-    static class ChunkBuffer extends DataOutputStream {
-        final ByteArrayOutputStream buffer;
-        final CRC32 crc;
-
-        ChunkBuffer(int initialSize) {
-            this(new ByteArrayOutputStream(initialSize), new CRC32());
-        }
-
-        private ChunkBuffer(ByteArrayOutputStream buffer, CRC32 crc) {
-            super(new CheckedOutputStream(buffer, crc));
-            this.buffer = buffer;
-            this.crc = crc;
-        }
-
-        public void endChunk(DataOutputStream target) throws IOException {
-            flush();
-            target.writeInt(buffer.size() - 4);
-            buffer.writeTo(target);
-            target.writeInt((int) crc.getValue());
-            buffer.reset();
-            crc.reset();
-        }
+        indexedPngWriter.write(file, pm, rgba);
     }
 
 }

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -113,58 +113,64 @@ public class Main extends ApplicationAdapter {
     }
 
     private void runSpecialCommand() {
-        String command = config.specialCommand;
+        FontwriterConfig.SpecialCommand command = config.specialCommand;
+        String inPath = config.resolveSpecialCommandPath();
 
-        if ("bulk".equals(command)) {
-            String inPath = config.specialCommandPath != null ? config.specialCommandPath : "input";
-            FileHandle[] files = Gdx.files.local(inPath).list(
-                    (dir, name) -> name.endsWith("ttf") || name.endsWith("otf"));
-            FontwriterConfig.Mode[] fields = {FontwriterConfig.Mode.STANDARD, FontwriterConfig.Mode.SDF, FontwriterConfig.Mode.MSDF};
-            for (FileHandle file : files) {
-                for (FontwriterConfig.Mode field : fields) {
-                    FontwriterConfig bulkConfig = new FontwriterConfig();
-                    bulkConfig.fontPath = file.path();
-                    bulkConfig.mode = field;
-                    if (file.name().startsWith("Go-Noto")) {
-                        bulkConfig.initialSize = "30";
-                        bulkConfig.imageSize = "4096x4096";
-                    } else {
-                        bulkConfig.initialSize = "280";
-                        bulkConfig.imageSize = "2048x2048";
+        switch (command) {
+            case BULK: {
+                FileHandle[] files = Gdx.files.local(inPath).list(
+                        (dir, name) -> name.endsWith("ttf") || name.endsWith("otf"));
+                FontwriterConfig.Mode[] modes = {FontwriterConfig.Mode.STANDARD, FontwriterConfig.Mode.SDF, FontwriterConfig.Mode.MSDF};
+                for (FileHandle file : files) {
+                    for (FontwriterConfig.Mode m : modes) {
+                        FontwriterConfig bulkConfig = new FontwriterConfig();
+                        bulkConfig.fontPath = file.path();
+                        bulkConfig.mode = m;
+                        if (file.name().startsWith("Go-Noto")) {
+                            bulkConfig.initialSize = "30";
+                            bulkConfig.imageSize = "4096x4096";
+                        } else {
+                            bulkConfig.initialSize = "280";
+                            bulkConfig.imageSize = "2048x2048";
+                        }
+                        bulkConfig.color = "black";
+                        this.config = bulkConfig;
+                        mainProcess();
                     }
-                    bulkConfig.color = "black";
-                    this.config = bulkConfig;
-                    mainProcess();
                 }
+                break;
             }
-        } else if ("preview".equals(command)) {
-            String inPath = config.specialCommandPath != null ? config.specialCommandPath : "fonts";
-            FileHandle[] files = Gdx.files.local(inPath).list(
-                    (dir, name) -> name.endsWith("json"));
-            for (FileHandle file : files) {
-                String filePath = file.path().substring(0, file.path().lastIndexOf('-'));
-                String fileMode = file.nameWithoutExtension().substring(file.nameWithoutExtension().lastIndexOf('-') + 1);
-                String fontName = filePath.substring(Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\')) + 1);
+            case PREVIEW: {
+                FileHandle[] files = Gdx.files.local(inPath).list(
+                        (dir, name) -> name.endsWith("json"));
+                for (FileHandle file : files) {
+                    String filePath = file.path().substring(0, file.path().lastIndexOf('-'));
+                    String fileMode = file.nameWithoutExtension().substring(file.nameWithoutExtension().lastIndexOf('-') + 1);
+                    String fontName = filePath.substring(Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\')) + 1);
 
-                FontwriterConfig previewConfig = new FontwriterConfig();
-                previewConfig.fontPath = filePath;
-                previewConfig.mode = FontwriterConfig.Mode.fromString(fileMode);
-                this.config = previewConfig;
-                makePreview(inPath + "/", fontName);
+                    FontwriterConfig previewConfig = new FontwriterConfig();
+                    previewConfig.fontPath = filePath;
+                    previewConfig.mode = FontwriterConfig.Mode.fromString(fileMode);
+                    this.config = previewConfig;
+                    makePreview(inPath + "/", fontName);
+                }
+                break;
             }
-        } else if ("ubj".equals(command)) {
-            String inPath = config.specialCommandPath != null ? config.specialCommandPath : "fonts";
-            FileHandle[] files = Gdx.files.local(inPath).list(
-                    (dir, name) -> name.endsWith("json"));
-            for (FileHandle file : files) {
-                convertToUBJSON(file);
+            case UBJ: {
+                FileHandle[] files = Gdx.files.local(inPath).list(
+                        (dir, name) -> name.endsWith("json"));
+                for (FileHandle file : files) {
+                    convertToUBJSON(file);
+                }
+                break;
             }
-        } else if ("lzma".equals(command)) {
-            String inPath = config.specialCommandPath != null ? config.specialCommandPath : "fonts";
-            FileHandle[] files = Gdx.files.local(inPath).list(
-                    (dir, name) -> name.endsWith("json"));
-            for (FileHandle file : files) {
-                convertToLzma(file);
+            case LZMA: {
+                FileHandle[] files = Gdx.files.local(inPath).list(
+                        (dir, name) -> name.endsWith("json"));
+                for (FileHandle file : files) {
+                    convertToLzma(file);
+                }
+                break;
             }
         }
     }

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -11,7 +11,23 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 
-/** {@link com.badlogic.gdx.ApplicationListener} implementation shared by all platforms. */
+/**
+ * {@link com.badlogic.gdx.ApplicationListener} implementation shared by all platforms.
+ * <p>
+ * Main owns the top-level font generation pipeline. On startup it parses
+ * the CLI args into a {@link FontwriterConfig}, detects the host OS to
+ * pick the correct {@code distbin/} directory for the bundled
+ * msdf-atlas-gen and oxipng binaries, and then — once libGDX has
+ * created a GL context in {@link #create()} — either dispatches to
+ * {@link #runSpecialCommand()} (for {@code --bulk}, {@code --preview},
+ * {@code --ubj}, {@code --lzma}) or runs {@link #mainProcess()} once
+ * for the single font requested on the command line.
+ * <p>
+ * The heavy lifting is delegated to small single-purpose classes in
+ * this package: {@link CharMapBuilder}, {@link FontwriterUtils},
+ * {@link PreviewRenderer}, {@link IndexedPngWriter}, {@link BinaryExec},
+ * and {@link LangFileResolver}. Main itself is just the orchestrator.
+ */
 public class Main extends ApplicationAdapter {
 
     private final IndexedPngWriter indexedPngWriter = new IndexedPngWriter();
@@ -133,7 +149,25 @@ public class Main extends ApplicationAdapter {
         }
     }
 
+    /**
+     * Runs the full single-font generation pipeline for the currently
+     * active {@link #config}. This is the method that actually produces
+     * the deliverables for one {@code (font, mode)} pair.
+     * <p>
+     * Step [5] is the one non-obvious part: msdf-atlas-gen fails with a
+     * non-zero exit code when the requested glyphs don't fit into the
+     * chosen image dimensions at the chosen font size. Rather than
+     * asking the user to guess, Main retries with {@code size - 1} on
+     * every failure and gives up only when size drops to zero. The
+     * {@code -pxrange} argument is recomputed on every retry because
+     * it's derived from the current size.
+     * <p>
+     * This method assumes it's being called on the libGDX render thread
+     * because step [9] (preview rendering) uses a shared {@link SpriteBatch}
+     * and reads back the GL back buffer.
+     */
     public void mainProcess() {
+        // [1] Resolve font file handle (absolute path preferred, local fallback)
         String fontFileName = config.fontPath;
         FontwriterConfig.Mode mode = config.mode;
         FileHandle fontHandle = Gdx.files.absolute(fontFileName);
@@ -141,8 +175,12 @@ public class Main extends ApplicationAdapter {
             fontHandle = Gdx.files.local(fontFileName);
         }
         String fontName = fontHandle.nameWithoutExtension();
+
+        // [2] Build the character map (cmap) file for msdf-atlas-gen
         FileHandle cmap = fontHandle.sibling(fontHandle.name() + ".cmap.txt");
         int cmapLength = CharMapBuilder.build(config, fontFileName, cmap);
+
+        // [3] Pick initial atlas size and image dimensions
         long size = Math.round(Double.parseDouble(config.initialSize));
         size = Math.min(cmapLength >= 30000 ? 55 : 280, size);
         String imageSize = config.resolveImageSize(cmapLength);
@@ -153,6 +191,8 @@ public class Main extends ApplicationAdapter {
         else {
             fullPreviewColor = -1;
         }
+
+        // [4] Assemble the msdf-atlas-gen command
         System.out.println("Generating structured JSON font and PNG using msdf-atlas-gen...");
         List<String> commandList = new ArrayList<>();
         commandList.add(archPath + atlasGenBinary);
@@ -177,6 +217,7 @@ public class Main extends ApplicationAdapter {
         commandList.add("-outerpxpadding");
         commandList.add("1");
 
+        // [5] Run msdf-atlas-gen, shrinking the font size on failure until it fits
         File workingDir = new File(Gdx.files.getLocalStoragePath());
         System.out.println("Running command: " + String.join(" ", commandList));
         while (true) {
@@ -198,6 +239,7 @@ public class Main extends ApplicationAdapter {
             }
         }
 
+        // [6] Compress the generated JSON into UBJ, LZMA, and LZB (.dat) companion files
         System.out.println("Compressing .JSON file (optional)...");
         FileHandle jsonHandle = Gdx.files.local("fonts/" + fontName + "-" + mode + ".json");
         FontwriterUtils.convertToUBJSON(jsonHandle);
@@ -205,6 +247,7 @@ public class Main extends ApplicationAdapter {
         ByteArray ba = LZBCompression.compressToByteArray(jsonHandle.readString("UTF8"));
         Gdx.files.local("fonts/" + fontName + "-" + mode + ".dat").writeBytes(ba.items, 0, ba.size, false);
 
+        // [7] Post-process the atlas PNG (stamp marker corner, optional color preview, palette convert)
         System.out.println("Applying changes for improved TextraTypist usage...");
         FileHandle imageFile = Gdx.files.local("fonts/" + fontName + "-" + mode + ".png");
         FileHandle fullPreviewFile = imageFile;
@@ -215,6 +258,7 @@ public class Main extends ApplicationAdapter {
         }
         process(imageFile, NO_COLOR_OVERRIDE);
 
+        // [8] Optimize the atlas PNG (and color preview, if any) with oxipng
         System.out.println("Optimizing result with oxipng...");
 
         List<String> oxiCmd = new ArrayList<>();
@@ -233,8 +277,10 @@ public class Main extends ApplicationAdapter {
             System.out.println("Running command: " + String.join(" ", oxiCmd));
             BinaryExec.runOrExit(archPath + oxipngBinary, "oxipng", oxiCmd, workingDir);
         }
+        // [9] Render the documentation preview PNG for the generated font
         previewRenderer.render(config, "fonts/", fontName);
 
+        // [10] Print a summary listing every file produced for this font
         // --- Summary: list all generated files with full paths ---
         System.out.println();
         System.out.println("Done! Generated files:");
@@ -268,6 +314,30 @@ public class Main extends ApplicationAdapter {
      */
     private static final int NO_COLOR_OVERRIDE = 256;
 
+    /**
+     * Post-processes an atlas PNG generated by msdf-atlas-gen so that it
+     * works correctly as a TextraTypist bitmap font texture.
+     * <p>
+     * Two things happen here:
+     * <ol>
+     *   <li>The bottom-right 3x3 corner is stamped opaque white. This
+     *       corner is reserved as a solid pixel that TextraTypist can
+     *       sample for color-tinted effects and rectangle fills without
+     *       having to allocate a second texture. If the caller did not
+     *       supply an explicit palette color ({@link #NO_COLOR_OVERRIDE}),
+     *       the corner is first checked to make sure no real glyph
+     *       pixels will be overwritten; finding any non-transparent
+     *       pixels there is treated as a fatal error.</li>
+     *   <li>MSDF atlases are left as full RGBA PNGs. STANDARD and SDF
+     *       atlases are instead rewritten through {@link IndexedPngWriter}
+     *       as 8-bit palette PNGs, which is drastically smaller for the
+     *       single-channel data these modes produce.</li>
+     * </ol>
+     *
+     * @param file the atlas PNG to rewrite in place
+     * @param rgba either an RGBA8888 palette color for the color preview,
+     *             or {@link #NO_COLOR_OVERRIDE} for the normal atlas path
+     */
     private void process (FileHandle file, int rgba) {
         if (!file.exists()) {
             System.out.println("The specified file " + file + " does not exist; skipping.");

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -16,13 +16,9 @@ import com.github.tommyettinger.textra.utils.LZBCompression;
 import com.github.tommyettinger.textra.utils.StringUtils;
 
 import java.io.*;
-import java.lang.StringBuilder;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-
-import static java.awt.Font.TRUETYPE_FONT;
 
 /** {@link com.badlogic.gdx.ApplicationListener} implementation shared by all platforms. */
 public class Main extends ApplicationAdapter {
@@ -168,107 +164,7 @@ public class Main extends ApplicationAdapter {
         }
         String fontName = fontHandle.nameWithoutExtension();
         FileHandle cmap = fontHandle.sibling(fontHandle.name() + ".cmap.txt");
-        int cmapLength;
-
-        // ---------------------------------------------------------------
-        //  Character set resolution — fallback hierarchy:
-        //
-        //  1. --charset given  → use that predefined set
-        //  2. --lang given     → extract chars from matched files (folder, glob, or file)
-        //                        (plus ASCII 32–126 baseline)
-        //  3. neither given    → all visible chars (codepoints 32–65535)
-        //
-        //  See FontwriterConfig.resolveCharsetStrategy() for the logic.
-        // ---------------------------------------------------------------
-        FontwriterConfig.CharsetStrategy charsetStrategy = config.resolveCharsetStrategy();
-        IntSet charSet = new IntSet(65536);
-
-        if (charsetStrategy == FontwriterConfig.CharsetStrategy.PRESET) {
-            System.out.println("Building character map from predefined charset: " + config.charset + "...");
-            populateCharset(charSet, config.charset);
-        } else if (charsetStrategy == FontwriterConfig.CharsetStrategy.LANG) {
-            System.out.println("Building character map from I18N source: " + config.langPath + "...");
-            // Baseline: ASCII + extended ASCII (32–255)
-            for (int i = 32; i <= 255; i++) {
-                charSet.add(i);
-            }
-
-            // --lang accepts three forms:
-            //   1. Glob pattern  — contains * or ? → match files against the pattern
-            //   2. Single file   — path points to an existing file → read that one file
-            //   3. Folder        — path points to a directory → read all files in it
-            FileHandle[] langFiles = LangFileResolver.resolve(config.langPath);
-
-            if (langFiles != null && langFiles.length > 0) {
-                for (FileHandle f : langFiles) {
-                    try {
-                        String content = f.readString("UTF-8");
-                        for (int i = 0; i < content.length(); i++) {
-                            charSet.add(content.charAt(i));
-                        }
-                        System.out.println("  Read " + f.path() + " (" + content.length() + " chars)");
-                    } catch (Exception e) {
-                        System.err.println("Failed to read " + f.path() + ": " + e.getMessage());
-                    }
-                }
-                System.out.println("  Unique characters found: " + charSet.size);
-            } else {
-                CliMessages.printLangNoMatches(config.langPath);
-                System.exit(1);
-            }
-        } else {
-            // "all" — no --charset, no --lang: include every character in the font.
-            System.out.println("Building character map from all visible characters in the font...");
-            for (int i = 32; i < 65536; i++) {
-                charSet.add(i);
-            }
-        }
-
-        // Weird/control chars to exclude
-        int[] weirdChars =
-            {0x200C, 0x200D, 0x200E, 0x200F, 0x2028, 0x2029, 0x202A, 0x202B, 0x202C, 0x202D, 0x202E, 0x206A,
-                0x206B, 0x206C, 0x206D, 0x206E, 0x206F};
-
-        // Filter only displayable characters
-        IntArray displayableChars = new IntArray(charSet.size);
-        // If there are a lot of chars, don't report every one that this can't display.
-        boolean reasonableCharMap = charSet.size < 10000;
-        try {
-            java.awt.Font af = java.awt.Font.createFont(TRUETYPE_FONT, new File(fontFileName));
-            IntSet.IntSetIterator iter = charSet.iterator();
-            while (iter.hasNext) {
-                int code = iter.next();
-                // Skip control chars and weird formatting chars
-                if (code < 32 || (code >= 0x7F && code <= 0x9F) ||         /* C1 controls */
-                    Arrays.binarySearch(weirdChars, code) >= 0) {
-                    continue;
-                }
-
-                if (af.canDisplay(code)) {
-                    displayableChars.add(code);
-                } else if (reasonableCharMap) {
-                    char ch = (char) code;
-                    String printable = (ch >= 32 && ch <= 126) ? String.valueOf(ch) : "\\u" + String.format("%04X", code);
-                    System.out.println("Font cannot display code " + code + " (" + printable + ")");
-                }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            System.exit(1);
-        }
-
-        // Build final string without trailing space
-        StringBuilder sb = new StringBuilder(4096);
-
-        for (int i = 0, n = displayableChars.size; i < n; i++) {
-            sb.append(displayableChars.get(i));
-            if (i + 1 < n) {
-                sb.append(' ');
-            }
-        }
-
-        cmap.writeString(sb.toString(), false, "UTF-8");
-        cmapLength = sb.length();
+        int cmapLength = CharMapBuilder.build(config, fontFileName, cmap);
         long size = Math.round(Double.parseDouble(config.initialSize));
         size = Math.min(cmapLength >= 30000 ? 55 : 280, size);
         String imageSize = config.resolveImageSize(cmapLength);
@@ -381,71 +277,6 @@ public class Main extends ApplicationAdapter {
             if (colorPreview.exists()) {
                 System.out.println("  " + colorPreview.file().getAbsolutePath());
             }
-        }
-    }
-
-    /**
-     * Populates the given IntSet with codepoints for a predefined charset.
-     * Every set includes ASCII 32–126 as a baseline.
-     *
-     * @param charSet the set to populate (not cleared first)
-     * @param charset the predefined charset to apply
-     */
-    private static void populateCharset(IntSet charSet, FontwriterConfig.Charset charset) {
-        // ASCII baseline (32–126) — always included
-        for (int i = 32; i <= 126; i++) {
-            charSet.add(i);
-        }
-
-        switch (charset) {
-            case ASCII:
-                // Already done above
-                break;
-
-            case LATIN:
-                // Latin-1 Supplement (160–255) + Latin Extended-A (256–383)
-                for (int i = 160; i <= 383; i++) {
-                    charSet.add(i);
-                }
-                break;
-
-            case LATIN_EXT:
-                // Latin-1 Supplement (160–255) + Latin Extended-A (256–383)
-                // + Latin Extended-B (384–591) + Latin Extended Additional (7680–7935)
-                for (int i = 160; i <= 591; i++) {
-                    charSet.add(i);
-                }
-                for (int i = 7680; i <= 7935; i++) {
-                    charSet.add(i);
-                }
-                break;
-
-            case CYRILLIC:
-                // Latin (160–383) + Cyrillic (1024–1279)
-                for (int i = 160; i <= 383; i++) {
-                    charSet.add(i);
-                }
-                for (int i = 1024; i <= 1279; i++) {
-                    charSet.add(i);
-                }
-                break;
-
-            case GREEK:
-                // Latin (160–383) + Greek and Coptic (880–1023)
-                for (int i = 160; i <= 383; i++) {
-                    charSet.add(i);
-                }
-                for (int i = 880; i <= 1023; i++) {
-                    charSet.add(i);
-                }
-                break;
-
-            case ALL:
-            default:
-                for (int i = 32; i < 65536; i++) {
-                    charSet.add(i);
-                }
-                break;
         }
     }
 

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -8,12 +8,9 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.utils.*;
-import com.badlogic.gdx.utils.compression.Lzma;
-import com.github.tommyettinger.textra.ColorLookup;
 import com.github.tommyettinger.textra.Font;
 import com.github.tommyettinger.textra.Layout;
 import com.github.tommyettinger.textra.utils.LZBCompression;
-import com.github.tommyettinger.textra.utils.StringUtils;
 
 import java.io.*;
 import java.nio.ByteBuffer;
@@ -140,7 +137,7 @@ public class Main extends ApplicationAdapter {
                 FileHandle[] files = Gdx.files.local(inPath).list(
                         (dir, name) -> name.endsWith("json"));
                 for (FileHandle file : files) {
-                    convertToUBJSON(file);
+                    FontwriterUtils.convertToUBJSON(file);
                 }
                 break;
             }
@@ -148,7 +145,7 @@ public class Main extends ApplicationAdapter {
                 FileHandle[] files = Gdx.files.local(inPath).list(
                         (dir, name) -> name.endsWith("json"));
                 for (FileHandle file : files) {
-                    convertToLzma(file);
+                    FontwriterUtils.convertToLzma(file);
                 }
                 break;
             }
@@ -171,7 +168,7 @@ public class Main extends ApplicationAdapter {
         boolean fullPreview = config.hasPreviewColor();
         int fullPreviewColor;
         if (fullPreview)
-            fullPreviewColor = stringToColor(config.color);
+            fullPreviewColor = FontwriterUtils.stringToColor(config.color);
         else {
             fullPreviewColor = -1;
         }
@@ -222,8 +219,8 @@ public class Main extends ApplicationAdapter {
 
         System.out.println("Compressing .JSON file (optional)...");
         FileHandle jsonHandle = Gdx.files.local("fonts/" + fontName + "-" + mode + ".json");
-        convertToUBJSON(jsonHandle);
-        convertToLzma(jsonHandle);
+        FontwriterUtils.convertToUBJSON(jsonHandle);
+        FontwriterUtils.convertToLzma(jsonHandle);
         ByteArray ba = LZBCompression.compressToByteArray(jsonHandle.readString("UTF8"));
         Gdx.files.local("fonts/" + fontName + "-" + mode + ".dat").writeBytes(ba.items, 0, ba.size, false);
 
@@ -329,75 +326,6 @@ public class Main extends ApplicationAdapter {
         System.out.println("Running command: " + String.join(" ", oxiCmd));
         BinaryExec.runOrExit(archPath + oxipngBinary, "oxipng", oxiCmd,
                 new File(Gdx.files.getLocalStoragePath()));
-    }
-
-    private void convertToUBJSON(FileHandle inFile){
-        try {
-            FileHandle
-                outFile = inFile.sibling(inFile.nameWithoutExtension() + ".ubj"),
-                outLzmaFile = inFile.sibling(inFile.nameWithoutExtension() + ".ubj.lzma");
-            UBJsonWriter ubWriter = new UBJsonWriter(outFile.write(false));
-            ubWriter.value(new JsonReader().parse(inFile));
-            ubWriter.close();
-
-            BufferedInputStream bais = new BufferedInputStream(outFile.read());
-            OutputStream lzmaOut = outLzmaFile.write(false);
-            Lzma.compress(bais, lzmaOut);
-            lzmaOut.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void convertToLzma(FileHandle inFile){
-        try {
-            FileHandle outLzmaFile = inFile.sibling(inFile.nameWithoutExtension() + ".json.lzma");
-
-            BufferedInputStream bais = new BufferedInputStream(inFile.read());
-            OutputStream lzmaOut = outLzmaFile.write(false);
-            Lzma.compress(bais, lzmaOut);
-            lzmaOut.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private int stringToColor(String str) {
-        if (str != null) {
-            // Try to parse named color
-            ColorLookup lookup = ColorLookup.DESCRIPTIVE;
-            int namedColor = lookup.getRgba(str);
-            if (namedColor != 256) {
-                return namedColor;
-            }
-            // Try to parse hex
-            if (str.length() >= 3) {
-                if (str.startsWith("#")) {
-                    if (str.length() >= 9) return StringUtils.intFromHex(str, 1, 9);
-                    if (str.length() >= 7) return StringUtils.intFromHex(str, 1, 7) << 8 | 0xFF;
-                    if (str.length() >= 4) {
-                        int rgb = StringUtils.intFromHex(str, 1, 4);
-                        return
-                                (rgb << 20 & 0xF0000000) | (rgb << 16 & 0x0F000000) |
-                                        (rgb << 16 & 0x00F00000) | (rgb << 12 & 0x000F0000) |
-                                        (rgb << 12 & 0x0000F000) | (rgb <<  8 & 0x00000F00) |
-                                        0xFF;
-                    }
-                } else {
-                    if (str.length() >= 8) return StringUtils.intFromHex(str, 0, 8);
-                    if (str.length() >= 6) return StringUtils.intFromHex(str, 0, 6) << 8 | 0xFF;
-                    int rgb = StringUtils.intFromHex(str, 0, 3);
-                    return
-                            (rgb << 20 & 0xF0000000) | (rgb << 16 & 0x0F000000) |
-                                    (rgb << 16 & 0x00F00000) | (rgb << 12 & 0x000F0000) |
-                                    (rgb << 12 & 0x0000F000) | (rgb <<  8 & 0x00000F00) |
-                                    0xFF;
-                }
-            }
-        }
-
-        return -1; // white
-
     }
 
     private void process (FileHandle file) {

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -197,7 +197,7 @@ public class Main extends ApplicationAdapter {
             //   1. Glob pattern  — contains * or ? → match files against the pattern
             //   2. Single file   — path points to an existing file → read that one file
             //   3. Folder        — path points to a directory → read all files in it
-            FileHandle[] langFiles = resolveLangFiles(config.langPath);
+            FileHandle[] langFiles = LangFileResolver.resolve(config.langPath);
 
             if (langFiles != null && langFiles.length > 0) {
                 for (FileHandle f : langFiles) {
@@ -382,89 +382,6 @@ public class Main extends ApplicationAdapter {
                 System.out.println("  " + colorPreview.file().getAbsolutePath());
             }
         }
-    }
-
-    /**
-     * Resolves the --lang value into an array of files to read.
-     * Three modes are supported:
-     * <ol>
-     *   <li><b>Glob pattern</b> (contains {@code *} or {@code ?}):
-     *       The parent directory is listed and filenames are matched
-     *       against the glob portion. Example: {@code "i18n/*.txt"},
-     *       {@code "i18n/*"}.</li>
-     *   <li><b>Single file</b> (path points to an existing file):
-     *       Returns an array with just that one file.</li>
-     *   <li><b>Folder</b> (path points to an existing directory):
-     *       Reads all files in that directory (excluding hidden
-     *       dot-files). Equivalent to passing the folder with "/*".</li>
-     * </ol>
-     *
-     * @param langPath the raw --lang value from the user
-     * @return matched files, or null/empty if nothing was found
-     */
-    private FileHandle[] resolveLangFiles(String langPath) {
-        // --- Mode 1: Glob pattern (contains * or ?) ---
-        if (langPath.contains("*") || langPath.contains("?")) {
-            // Split into parent directory + filename pattern.
-            // e.g. "i18n/*.txt" → parent="i18n", pattern="*.txt"
-            // e.g. "i18n/*"          → parent="i18n", pattern="*"
-            int lastSep = Math.max(langPath.lastIndexOf('/'), langPath.lastIndexOf('\\'));
-            String parentPath;
-            String globPattern;
-            if (lastSep >= 0) {
-                parentPath = langPath.substring(0, lastSep);
-                globPattern = langPath.substring(lastSep + 1);
-            } else {
-                parentPath = ".";
-                globPattern = langPath;
-            }
-
-            FileHandle parentDir = Gdx.files.absolute(parentPath);
-            if (!parentDir.exists()) parentDir = Gdx.files.local(parentPath);
-            if (!parentDir.exists() || !parentDir.isDirectory()) {
-                CliMessages.printLangParentMissing(parentPath);
-                return null;
-            }
-
-            // Convert glob to regex: escape dots, * → .*, ? → .
-            final String regex = "^" + globPattern
-                    .replace(".", "\\.")
-                    .replace("*", ".*")
-                    .replace("?", ".")
-                    + "$";
-
-            FileHandle[] matched = parentDir.list((d, name) -> name.matches(regex));
-            if (matched == null || matched.length == 0) {
-                CliMessages.printLangGlobNoMatch(globPattern, parentDir.path());
-            } else {
-                System.out.println("  Matched " + matched.length + " file(s) from pattern '" + langPath + "'.");
-            }
-            return matched;
-        }
-
-        // --- Mode 2 & 3: resolve as absolute or local path ---
-        FileHandle resolved = Gdx.files.absolute(langPath);
-        if (!resolved.exists()) resolved = Gdx.files.local(langPath);
-
-        if (!resolved.exists()) {
-            CliMessages.printLangPathMissing(langPath);
-            return null;
-        }
-
-        // --- Mode 2: Single file ---
-        if (!resolved.isDirectory()) {
-            System.out.println("  Using single file: " + resolved.path());
-            return new FileHandle[]{resolved};
-        }
-
-        // --- Mode 3: Folder — read all files in the directory ---
-        FileHandle[] langFiles = resolved.list((d, name) -> !name.startsWith("."));
-        if (langFiles == null || langFiles.length == 0) {
-            CliMessages.printLangFolderEmpty(langPath);
-        } else {
-            System.out.println("  Found " + langFiles.length + " file(s) in folder '" + langPath + "'.");
-        }
-        return langFiles;
     }
 
     /**

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -232,7 +232,7 @@ public class Main extends ApplicationAdapter {
             imageFile.copyTo(fullPreviewFile);
             process(fullPreviewFile, fullPreviewColor);
         }
-        process(imageFile);
+        process(imageFile, NO_COLOR_OVERRIDE);
 
         System.out.println("Optimizing result with oxipng...");
 
@@ -328,9 +328,16 @@ public class Main extends ApplicationAdapter {
                 new File(Gdx.files.getLocalStoragePath()));
     }
 
-    private void process (FileHandle file) {
-        process(file, 256);
-    }
+    /**
+     * Sentinel value for {@link #process(FileHandle, int)} meaning
+     * "no caller-supplied color": the method then validates that the
+     * bottom-right 3x3 corner of the atlas is safe to stamp over and
+     * falls back to opaque white ({@code -1}) as the palette RGB.
+     * Chosen as 256 because all real RGBA8888 values fit in 32 bits,
+     * so 256 is outside any legal color.
+     */
+    private static final int NO_COLOR_OVERRIDE = 256;
+
     private void process (FileHandle file, int rgba) {
         if (!file.exists()) {
             System.out.println("The specified file " + file + " does not exist; skipping.");
@@ -339,7 +346,7 @@ public class Main extends ApplicationAdapter {
         Pixmap pm = new Pixmap(file);
 
         final int w = pm.getWidth(), h = pm.getHeight();
-        if (rgba == 256) {
+        if (rgba == NO_COLOR_OVERRIDE) {
             for (int x = w - 3; x < w; x++) {
                 for (int y = h - 3; y < h; y++) {
                     int color = pm.getPixel(x, y);

--- a/core/src/main/java/com/github/tommyettinger/Main.java
+++ b/core/src/main/java/com/github/tommyettinger/Main.java
@@ -159,27 +159,6 @@ public class Main extends ApplicationAdapter {
         }
     }
 
-    /**
-     * Verifies that an external binary exists and is executable before
-     * attempting to run it. Prints a descriptive error message and exits
-     * if the binary is missing or not executable.
-     *
-     * @param binaryPath the relative path to the binary (e.g. "distbin/mac-arm64/msdf-atlas-gen")
-     * @param binaryName a human-readable name for error messages (e.g. "msdf-atlas-gen")
-     */
-    private void verifyBinary(String binaryPath, String binaryName) {
-        File binaryFile = new File(Gdx.files.getLocalStoragePath(), binaryPath);
-        if (!binaryFile.exists()) {
-            CliMessages.printBinaryNotFound(binaryName, binaryFile.getAbsolutePath());
-            System.exit(1);
-        }
-        if (!binaryFile.canExecute()) {
-            CliMessages.printBinaryNotExecutable(binaryName, binaryPath,
-                    binaryFile.getAbsolutePath(), SharedLibraryLoader.os);
-            System.exit(1);
-        }
-    }
-
     public void mainProcess() {
         String fontFileName = config.fontPath;
         FontwriterConfig.Mode mode = config.mode;
@@ -324,39 +303,23 @@ public class Main extends ApplicationAdapter {
         commandList.add("-outerpxpadding");
         commandList.add("1");
 
-        verifyBinary(archPath + atlasGenBinary, "msdf-atlas-gen");
-
-        ProcessBuilder builder = new ProcessBuilder(commandList);
-        System.out.println("Running command: " + String.join(" ", builder.command()));
-
-        builder.directory(new File(Gdx.files.getLocalStoragePath()));
-        builder.inheritIO();
+        File workingDir = new File(Gdx.files.getLocalStoragePath());
+        System.out.println("Running command: " + String.join(" ", commandList));
         while (true) {
-            try {
-                commandList.set(commandList.size() - 3, String.valueOf(size));
-                commandList.set(commandList.size() - 8, mode == FontwriterConfig.Mode.SDF ? String.valueOf(size * 0.15f) : String.valueOf(size * 0.1));
-                builder.command(commandList);
-                System.out.print("Trying size: " + size + "... ");
-                int exitCode = builder.start().waitFor();
-                if (exitCode != 0) {
-                    long failedSize = size;
-                    if (--size <= 0) {
-                        System.err.println("Error: msdf-atlas-gen could not fit glyphs into the atlas at any size "
-                            + "(last attempted: " + failedSize + "). Terminating.");
-                        System.exit(exitCode);
-                        break;
-                    }
-                } else {
-                    System.out.println("\nSuccessfully generated atlas using font size " + size + ".");
+            commandList.set(commandList.size() - 3, String.valueOf(size));
+            commandList.set(commandList.size() - 8, mode == FontwriterConfig.Mode.SDF ? String.valueOf(size * 0.15f) : String.valueOf(size * 0.1));
+            System.out.print("Trying size: " + size + "... ");
+            int exitCode = BinaryExec.run(archPath + atlasGenBinary, "msdf-atlas-gen", commandList, workingDir);
+            if (exitCode != 0) {
+                long failedSize = size;
+                if (--size <= 0) {
+                    System.err.println("Error: msdf-atlas-gen could not fit glyphs into the atlas at any size "
+                        + "(last attempted: " + failedSize + "). Terminating.");
+                    System.exit(exitCode);
                     break;
                 }
-            } catch (IOException e) {
-                CliMessages.printBinaryRunFailed("msdf-atlas-gen", e.getMessage(), SharedLibraryLoader.os);
-                System.exit(1);
-                break;
-            } catch (InterruptedException e) {
-                CliMessages.printBinaryInterrupted("msdf-atlas-gen", e.getMessage());
-                System.exit(1);
+            } else {
+                System.out.println("\nSuccessfully generated atlas using font size " + size + ".");
                 break;
             }
         }
@@ -379,7 +342,6 @@ public class Main extends ApplicationAdapter {
         process(imageFile);
 
         System.out.println("Optimizing result with oxipng...");
-        verifyBinary(archPath + oxipngBinary, "oxipng");
 
         List<String> oxiCmd = new ArrayList<>();
         oxiCmd.add(archPath + oxipngBinary);
@@ -389,40 +351,13 @@ public class Main extends ApplicationAdapter {
         oxiCmd.add("-s");
         oxiCmd.add(imageFile.path());
 
-        builder.command(oxiCmd);
-        System.out.println("Running command: " + String.join(" ", builder.command()));
+        System.out.println("Running command: " + String.join(" ", oxiCmd));
+        BinaryExec.runOrExit(archPath + oxipngBinary, "oxipng", oxiCmd, workingDir);
 
-        try {
-            int exitCode = builder.start().waitFor();
-            if (exitCode != 0) {
-                CliMessages.printBinaryExitFailure("oxipng", exitCode);
-                System.exit(exitCode);
-            }
-        } catch (IOException e) {
-            CliMessages.printBinaryRunFailed("oxipng", e.getMessage(), SharedLibraryLoader.os);
-            System.exit(1);
-        } catch (InterruptedException e) {
-            CliMessages.printBinaryInterrupted("oxipng", e.getMessage());
-            System.exit(1);
-        }
         if (fullPreview) {
             oxiCmd.set(oxiCmd.size() - 1, fullPreviewFile.path());
-            builder.command(oxiCmd);
-            System.out.println("Running command: " + String.join(" ", builder.command()));
-            try {
-                int exitCode = builder.start().waitFor();
-                if (exitCode != 0) {
-                    CliMessages.printBinaryExitFailure("oxipng", exitCode);
-                    System.exit(exitCode);
-                }
-            } catch (IOException e) {
-                CliMessages.printBinaryRunFailed("oxipng", e.getMessage(), SharedLibraryLoader.os);
-                System.exit(1);
-            } catch (InterruptedException e) {
-                CliMessages.printBinaryInterrupted("oxipng", e.getMessage());
-                System.exit(1);
-            }
-
+            System.out.println("Running command: " + String.join(" ", oxiCmd));
+            BinaryExec.runOrExit(archPath + oxipngBinary, "oxipng", oxiCmd, workingDir);
         }
         makePreview("fonts/", fontName);
 
@@ -643,27 +578,9 @@ public class Main extends ApplicationAdapter {
         oxiCmd.add("-s");
         oxiCmd.add(previewFile.path());
 
-        // Verify oxipng binary — this method is also called from --preview,
-        // which does not go through mainProcess(), so we must check here.
-        verifyBinary(archPath + oxipngBinary, "oxipng");
-
-        ProcessBuilder builder = new ProcessBuilder(oxiCmd);
-        builder.directory(new File(Gdx.files.getLocalStoragePath()));
-        builder.inheritIO();
-        System.out.println("Running command: " + String.join(" ", builder.command()));
-        try {
-            int exitCode = builder.start().waitFor();
-            if (exitCode != 0) {
-                CliMessages.printBinaryExitFailure("oxipng", exitCode);
-                System.exit(exitCode);
-            }
-        } catch (IOException e) {
-            CliMessages.printBinaryRunFailed("oxipng", e.getMessage(), SharedLibraryLoader.os);
-            System.exit(1);
-        } catch (InterruptedException e) {
-            CliMessages.printBinaryInterrupted("oxipng", e.getMessage());
-            System.exit(1);
-        }
+        System.out.println("Running command: " + String.join(" ", oxiCmd));
+        BinaryExec.runOrExit(archPath + oxipngBinary, "oxipng", oxiCmd,
+                new File(Gdx.files.getLocalStoragePath()));
     }
 
     private void convertToUBJSON(FileHandle inFile){

--- a/core/src/main/java/com/github/tommyettinger/PreviewRenderer.java
+++ b/core/src/main/java/com/github/tommyettinger/PreviewRenderer.java
@@ -10,6 +10,7 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.ScreenUtils;
 import com.github.tommyettinger.textra.Font;
 import com.github.tommyettinger.textra.Layout;
@@ -35,7 +36,7 @@ import java.util.List;
  * {@code previews/&lt;fontName&gt;-&lt;mode&gt;.png} and then optimized
  * in place with oxipng via {@link BinaryExec#runOrExit}.
  */
-final class PreviewRenderer {
+final class PreviewRenderer implements Disposable {
 
     /**
      * Markup text used for every preview image. It exercises most of
@@ -141,5 +142,16 @@ final class PreviewRenderer {
         System.out.println("Running command: " + String.join(" ", oxiCmd));
         BinaryExec.runOrExit(archPath + oxipngBinary, "oxipng", oxiCmd,
                 new File(Gdx.files.getLocalStoragePath()));
+    }
+
+    /**
+     * Releases the native GL resources owned by this renderer — namely
+     * the {@link SpriteBatch} allocated in the constructor. Must be
+     * called on the libGDX render thread before application shutdown.
+     * After calling this, {@link #render} must not be called again.
+     */
+    @Override
+    public void dispose() {
+        batch.dispose();
     }
 }

--- a/core/src/main/java/com/github/tommyettinger/PreviewRenderer.java
+++ b/core/src/main/java/com/github/tommyettinger/PreviewRenderer.java
@@ -1,0 +1,145 @@
+package com.github.tommyettinger;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.PixmapIO;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.utils.ScreenUtils;
+import com.github.tommyettinger.textra.Font;
+import com.github.tommyettinger.textra.Layout;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Renders the per-font preview PNG used as documentation of what
+ * each generated atlas actually looks like at runtime.
+ * <p>
+ * Unlike the other extractions in this package, PreviewRenderer is a
+ * <b>stateful</b> class rather than a static utility: it owns its
+ * own {@link SpriteBatch} and reusable {@link Layout}, and it must
+ * run on the libGDX render thread because it draws into the back
+ * buffer and then calls {@code glReadPixels} to capture the result.
+ * A single instance is expected to be constructed once per
+ * application run, after the GL context is ready.
+ * <p>
+ * After rendering, the captured pixels are written to
+ * {@code previews/&lt;fontName&gt;-&lt;mode&gt;.png} and then optimized
+ * in place with oxipng via {@link BinaryExec#runOrExit}.
+ */
+final class PreviewRenderer {
+
+    /**
+     * Markup text used for every preview image. It exercises most of
+     * TextraTypist's renderer (colors, bold/italic/underline, scale,
+     * sub/superscript, case transforms, effects, neon, etc.) so the
+     * generated preview gives a reasonably representative sample of
+     * what the font can do.
+     */
+    private static final String TEXT = "Fonts can be rendered normally,{CURLY BRACKETS ARE IGNORED} but using [[tags], you can..."
+            + "\n[#E74200]...use CSS-style hex colors like [*]#E74200[*]..."
+            + "\n[darker purple blue]...use color names or descriptions, like [/]darker purple blue[/]...[ ]"
+            + "\n[_]...and use [!]effects[!][_]!"
+            + "\nNormal, [*]bold[*], [/]oblique[/] (like italic), [*][/]bold oblique[ ],"
+            + "\n[_]underline (even for multiple words)[_], [~]strikethrough (same)[ ],"
+            + "\nscaling: [%50]very [%75]small [%100]to [%150]quite [%200]large[ ], notes: [.]sub-[.], [=]mid-[=], and [^]super-[^]script,"
+            + "\ncapitalization changes: [;]Each cap, [,]All lower, [!]Caps lock[ ],"
+            + "\n[?small caps][*]Special[*][?] [?whiten][/]Effects[/][?][#]: [?shadow]drop shadow[?], [?jostle]RaNsoM nOtE[?], [?error]spell check[?]..."
+            + "\nWelcome to the [TEAL][?neon]Structured JSON Zone[ ]!";
+
+    private final SpriteBatch batch;
+    private final Layout layout;
+    private final String archPath;
+    private final String oxipngBinary;
+
+    /**
+     * Constructs a renderer. Must be called on the libGDX render
+     * thread, because it allocates a {@link SpriteBatch}. The
+     * per-font configuration is passed to {@link #render} instead of
+     * captured here, so a single instance can handle a sequence of
+     * fonts (as in {@code --bulk} mode, where the active config
+     * rotates between fonts).
+     *
+     * @param archPath     platform-specific {@code distbin/} directory
+     *                     containing the oxipng executable
+     * @param oxipngBinary bare filename of the oxipng executable
+     *                     ({@code oxipng} or {@code oxipng.exe})
+     */
+    PreviewRenderer(String archPath, String oxipngBinary) {
+        this.archPath = archPath;
+        this.oxipngBinary = oxipngBinary;
+        this.batch = new SpriteBatch();
+        this.layout = new Layout().setTargetWidth(1200);
+    }
+
+    /**
+     * Renders a preview for the given font and writes it to
+     * {@code previews/&lt;fontName&gt;-&lt;mode&gt;.png}, then runs
+     * oxipng over the result.
+     *
+     * @param config   configuration for this particular font (used
+     *                 only for {@link FontwriterConfig#mode})
+     * @param inPath   directory (with trailing slash) containing the
+     *                 {@code <fontName>-<mode>.png} and
+     *                 {@code <fontName>-<mode>.json} pair
+     * @param fontName base name of the font (no extension)
+     */
+    public void render(FontwriterConfig config, String inPath, String fontName) {
+        FontwriterConfig.Mode mode = config.mode;
+        System.out.println("Creating a preview for " + fontName + "-" + mode + "...");
+        Texture fontTexture = new Texture(inPath + fontName + "-" + mode + ".png");
+        Font font = new Font(inPath + fontName + "-" + mode + ".json",
+                new TextureRegion(fontTexture), 0f, 0f, 0f, 0f,
+                true, true);
+        if (fontTexture.getWidth() >= 1024 && fontTexture.getHeight() >= 1024)
+            font.scaleHeightTo(32f);
+        else
+            font.scale(Math.round(512f / fontTexture.getHeight()))
+                .setTextureFilter(Texture.TextureFilter.Nearest, Texture.TextureFilter.Nearest)
+                .useIntegerPositions(true); // for pixel fonts
+        font.resizeDistanceField(Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
+
+        layout.setBaseColor(Color.DARK_GRAY);
+        layout.setMaxLines(20);
+        layout.setEllipsis(" and so on and so forth...");
+        font.markup(TEXT, layout);
+
+        ScreenUtils.clear(0.75f, 0.75f, 0.75f, 1f);
+        float x = Gdx.graphics.getBackBufferWidth() * 0.5f;
+        float y = (Gdx.graphics.getBackBufferHeight() + layout.getHeight()) * 0.5f;
+        batch.begin();
+        font.enableShader(batch);
+        font.drawGlyphs(batch, layout, x, y, Align.center);
+        batch.end();
+
+        // Modified Pixmap.createFromFrameBuffer() code that uses RGB instead of RGBA
+        Gdx.gl.glPixelStorei(GL20.GL_PACK_ALIGNMENT, 1);
+        final Pixmap pm = new Pixmap(Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), Pixmap.Format.RGB888);
+        ByteBuffer pixels = pm.getPixels();
+        Gdx.gl.glReadPixels(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, pixels);
+        // End Pixmap.createFromFrameBuffer() modified code
+
+        FileHandle previewFile = Gdx.files.local("previews/" + fontName + "-" + mode + ".png");
+        PixmapIO.writePNG(previewFile, pm, 0, true);
+
+        List<String> oxiCmd = new ArrayList<>();
+        oxiCmd.add(archPath + oxipngBinary);
+        oxiCmd.add("-o");
+        oxiCmd.add("6");
+        oxiCmd.add("--ng");
+        oxiCmd.add("-s");
+        oxiCmd.add(previewFile.path());
+
+        System.out.println("Running command: " + String.join(" ", oxiCmd));
+        BinaryExec.runOrExit(archPath + oxipngBinary, "oxipng", oxiCmd,
+                new File(Gdx.files.getLocalStoragePath()));
+    }
+}


### PR DESCRIPTION
## Summary
Pure refactor of `core/src/main/java/com/github/tommyettinger/Main.java`, which had grown to ~1050 lines mixing CLI parsing, char map construction, binary execution, PNG post-processing, preview rendering, and compression into one class. This PR extracts those concerns into small single-purpose classes with no behavioral changes. `Main.java` goes from ~1050 lines to ~320.

## What changed
New classes (all in `com.github.tommyettinger`):
- `CliMessages` — user-facing help/version/error text
- `FontwriterConfig.BatchCommand` enum + updates to `ConfigParser` (batch-command dispatch for `--bulk` / `--preview` / `--ubj` / `--lzma`)
- `IndexedPngWriter` — indexed-PNG encoder previously inline in `Main`
- `BinaryExec` — `msdf-atlas-gen` / `oxipng` subprocess runner
- `LangFileResolver` — resolves `--lang` glob/file/folder input
- `CharMapBuilder` — builds the cmap passed to `msdf-atlas-gen`
- `FontwriterUtils` — stateless helpers (`stringToColor`, UBJ/LZMA conversion)
- `PreviewRenderer` — owns the per-font preview pipeline, now properly `Disposable`

Follow-up polish commits:
- Replaced a `process()` overload with a `NO_COLOR_OVERRIDE` sentinel.
- Added numbered step comments and javadocs to `Main.mainProcess()`.
- Renamed `SpecialCommand` → `BatchCommand` for clarity.
- Fixed a pre-existing leak by disposing `PreviewRenderer`'s `SpriteBatch` on shutdown.

13 atomic commits, each doing one thing, so the history should be reviewable commit-by-commit.

## How to test

./gradlew lwjgl3:jar
java -jar lwjgl3/build/libs/fontwriter-.jar <font.ttf> msdf 60
java -jar lwjgl3/build/libs/fontwriter-.jar --bulk input
java -jar lwjgl3/build/libs/fontwriter-*.jar --help
Output files (`.png`, `.json`, `.ubj`, `.dat`, `.lzma`, preview PNG) should be byte-for-byte equivalent to `main` for the same inputs — no code path was changed.

## Platform tested
macOS arm64. Other platforms untouched: the only OS-sensitive code path (`SharedLibraryLoader.os` branch in `Main`'s constructor) is unchanged.

## Notes
- No new dependencies.
- No changes to `lwjgl3/` or `distbin/`.
- Possible follow-ups as separate PRs: replacing the remaining `System.exit(1)` calls with exceptions, and adding first tests around `CharMapBuilder` and `FontwriterUtils.stringToColor` now that they're isolated.


- **Extract user-facing CLI messages into CliMessages class**
- **Introduce SpecialCommand enum for --bulk/--preview/--ubj/--lzma**
- **Extract indexed PNG encoder into IndexedPngWriter class**
- **Extract binary execution into BinaryExec helper**
- **Extract --lang file resolution into LangFileResolver**
- **Extract character map construction into CharMapBuilder**
- **Extract stateless helpers into FontwriterUtils**
- **Replace process() overload with NO_COLOR_OVERRIDE constant**
- **Extract preview rendering into PreviewRenderer class**
- **Document mainProcess pipeline with numbered steps and javadocs**
- **Rename SpecialCommand to BatchCommand**
- **Dispose PreviewRenderer's SpriteBatch on shutdown**
- **Update user-facing text from "special commands" to "batch commands"**
